### PR TITLE
Harden iClock server: fix race conditions, enforce HTTP methods, and add async callback dispatch

### DIFF
--- a/GETTING_STARTED.md
+++ b/GETTING_STARTED.md
@@ -4,7 +4,7 @@ This guide will help you get started with the ZK Device Sync library for integra
 
 ## Prerequisites
 
-- Go 1.16 or higher
+- Go 1.24 or higher
 - A ZKTeco biometric device (attendance machine)
 - Network access between your server and the device
 
@@ -175,7 +175,7 @@ This will return a JSON snapshot with devices, lastActivity (RFC3339), online fl
 http.HandleFunc("/devices", func(w http.ResponseWriter, r *http.Request) {
     devices := server.ListDevices()
     for _, device := range devices {
-        online := time.Since(device.LastActivity) <= 2*time.Minute
+        online := server.IsDeviceOnline(device.SerialNumber)
         fmt.Fprintf(w, "Device: %s, Last Seen: %s, Online: %t\n",
             device.SerialNumber,
             device.LastActivity.Format(time.RFC3339),

--- a/examples/basic_server.go
+++ b/examples/basic_server.go
@@ -15,6 +15,7 @@ import (
 func main() {
 	// Create a new iclock server
 	server := zkdevicesync.NewIClockServer()
+	defer server.Close()
 
 	// Set up callback for attendance records
 	server.OnAttendance = func(record zkdevicesync.AttendanceRecord) {
@@ -64,8 +65,10 @@ func main() {
 		w.Header().Set("Content-Type", "text/plain")
 		fmt.Fprintf(w, "Connected Devices: %d\n\n", len(devices))
 		for _, device := range devices {
+			online := server.IsDeviceOnline(device.SerialNumber)
 			fmt.Fprintf(w, "Serial Number: %s\n", device.SerialNumber)
 			fmt.Fprintf(w, "Last Activity: %s\n", device.LastActivity.Format(time.RFC3339))
+			fmt.Fprintf(w, "Online: %t\n", online)
 			fmt.Fprintf(w, "Options: %v\n", device.Options)
 			fmt.Fprintln(w, "---")
 		}

--- a/examples/database_integration.go
+++ b/examples/database_integration.go
@@ -8,7 +8,6 @@ import (
 	"time"
 
 	zkdevicesync "github.com/s0x90/zk-device-sync"
-	
 	// Uncomment when using actual database
 	// _ "github.com/lib/pq"
 )
@@ -34,14 +33,14 @@ func (s *AttendanceStore) SaveAttendance(record zkdevicesync.AttendanceRecord) e
 
 	// In a real application, you would insert into a database:
 	/*
-		query := `INSERT INTO attendance_records 
+		query := `INSERT INTO attendance_records
 				  (user_id, timestamp, status, verify_mode, work_code, device_sn)
 				  VALUES (?, ?, ?, ?, ?, ?)`
-		_, err := s.db.Exec(query, 
-			record.UserID, 
-			record.Timestamp, 
+		_, err := s.db.Exec(query,
+			record.UserID,
+			record.Timestamp,
 			record.Status,
-			record.VerifyMode, 
+			record.VerifyMode,
 			record.WorkCode,
 			record.SerialNumber)
 		return err
@@ -58,7 +57,7 @@ func (s *AttendanceStore) SaveAttendance(record zkdevicesync.AttendanceRecord) e
 func (s *AttendanceStore) GetRecords() []zkdevicesync.AttendanceRecord {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	
+
 	result := make([]zkdevicesync.AttendanceRecord, len(s.records))
 	copy(result, s.records)
 	return result
@@ -68,7 +67,7 @@ func (s *AttendanceStore) GetRecords() []zkdevicesync.AttendanceRecord {
 func (s *AttendanceStore) GetRecordsByUser(userID string) []zkdevicesync.AttendanceRecord {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	
+
 	var result []zkdevicesync.AttendanceRecord
 	for _, record := range s.records {
 		if record.UserID == userID {
@@ -82,7 +81,7 @@ func (s *AttendanceStore) GetRecordsByUser(userID string) []zkdevicesync.Attenda
 func (s *AttendanceStore) GetRecordsByDateRange(start, end time.Time) []zkdevicesync.AttendanceRecord {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	
+
 	var result []zkdevicesync.AttendanceRecord
 	for _, record := range s.records {
 		if record.Timestamp.After(start) && record.Timestamp.Before(end) {
@@ -98,6 +97,7 @@ func main() {
 
 	// Create the iclock server
 	server := zkdevicesync.NewIClockServer()
+	defer server.Close()
 
 	// Set up attendance callback to save to database
 	server.OnAttendance = func(record zkdevicesync.AttendanceRecord) {
@@ -117,9 +117,9 @@ func main() {
 	// API endpoint to query attendance records
 	http.HandleFunc("/api/attendance", func(w http.ResponseWriter, r *http.Request) {
 		userID := r.URL.Query().Get("user_id")
-		
+
 		w.Header().Set("Content-Type", "application/json")
-		
+
 		if userID != "" {
 			records := store.GetRecordsByUser(userID)
 			fmt.Fprintf(w, `{"user_id": "%s", "count": %d, "records": [`, userID, len(records))
@@ -155,13 +155,13 @@ func main() {
 		now := time.Now()
 		startOfDay := time.Date(now.Year(), now.Month(), now.Day(), 0, 0, 0, 0, now.Location())
 		endOfDay := startOfDay.Add(24 * time.Hour)
-		
+
 		records := store.GetRecordsByDateRange(startOfDay, endOfDay)
-		
+
 		w.Header().Set("Content-Type", "application/json")
 		fmt.Fprintf(w, `{"date": "%s", "count": %d, "records": [`,
 			startOfDay.Format("2006-01-02"), len(records))
-		
+
 		for i, record := range records {
 			if i > 0 {
 				fmt.Fprint(w, ",")
@@ -180,7 +180,7 @@ func main() {
 	log.Println("  /iclock/* - ZKTeco device endpoints")
 	log.Println("  /api/attendance - Query attendance records")
 	log.Println("  /api/summary/today - Get today's attendance summary")
-	
+
 	if err := http.ListenAndServe(addr, nil); err != nil {
 		log.Fatal(err)
 	}
@@ -209,7 +209,7 @@ func initDB() (*sql.DB, error) {
 		INDEX idx_device_timestamp (device_sn, timestamp)
 	);
 	`
-	
+
 	_, err = db.Exec(schema)
 	return db, err
 }

--- a/iclock.go
+++ b/iclock.go
@@ -153,10 +153,16 @@ func (s *IClockServer) safeCall(fn func()) {
 // dispatchCallback enqueues a callback for asynchronous execution.
 // If the callback channel is full or the server is closed, the event is dropped.
 func (s *IClockServer) dispatchCallback(fn func()) {
+	// Fast-path: if the server is already closing/closed, drop the callback.
+	select {
+	case <-s.closeCh:
+		return
+	default:
+	}
+
+	// Server is not closed at this point; try to enqueue without blocking.
 	select {
 	case s.callbackCh <- fn:
-	case <-s.closeCh:
-		// Server is closing, drop the callback.
 	default:
 		s.logger.Printf("[Callback] WARNING: callback queue full, dropping event")
 	}
@@ -590,15 +596,12 @@ func (s *IClockServer) HandleInspect(w http.ResponseWriter, r *http.Request) {
 
 	s.devicesMutex.RLock()
 	for _, d := range s.devices {
-		opts := make(map[string]string, len(d.Options))
-		for k, v := range d.Options {
-			opts[k] = v
-		}
+		dc := d.copy()
 		snap := DeviceSnapshot{
-			Serial:       d.SerialNumber,
-			LastActivity: d.LastActivity.Format(time.RFC3339),
+			Serial:       dc.SerialNumber,
+			LastActivity: dc.LastActivity.Format(time.RFC3339),
 			Online:       s.isDeviceOnline(d),
-			Options:      opts,
+			Options:      dc.Options,
 		}
 		snapshot.Devices = append(snapshot.Devices, snap)
 	}

--- a/iclock.go
+++ b/iclock.go
@@ -31,7 +31,6 @@ import (
 	"strconv"
 	"strings"
 	"sync"
-	"sync/atomic"
 	"time"
 )
 
@@ -90,8 +89,8 @@ type IClockServer struct {
 
 	callbackCh   chan func()
 	callbackDone chan struct{}
+	closeCh      chan struct{}
 	closeOnce    sync.Once
-	closed       atomic.Bool
 }
 
 // NewIClockServer creates a new iclock server instance.
@@ -103,6 +102,7 @@ func NewIClockServer() *IClockServer {
 		logger:       log.Default(),
 		callbackCh:   make(chan func(), 256),
 		callbackDone: make(chan struct{}),
+		closeCh:      make(chan struct{}),
 	}
 	go s.callbackWorker()
 	return s
@@ -113,8 +113,7 @@ func NewIClockServer() *IClockServer {
 // Close is safe to call multiple times.
 func (s *IClockServer) Close() {
 	s.closeOnce.Do(func() {
-		s.closed.Store(true)
-		close(s.callbackCh)
+		close(s.closeCh)
 		<-s.callbackDone
 	})
 }
@@ -123,8 +122,21 @@ func (s *IClockServer) Close() {
 // Panics in user callbacks are recovered so the worker stays alive.
 func (s *IClockServer) callbackWorker() {
 	defer close(s.callbackDone)
-	for fn := range s.callbackCh {
-		s.safeCall(fn)
+	for {
+		select {
+		case fn := <-s.callbackCh:
+			s.safeCall(fn)
+		case <-s.closeCh:
+			// Drain remaining callbacks before exiting.
+			for {
+				select {
+				case fn := <-s.callbackCh:
+					s.safeCall(fn)
+				default:
+					return
+				}
+			}
+		}
 	}
 }
 
@@ -141,11 +153,10 @@ func (s *IClockServer) safeCall(fn func()) {
 // dispatchCallback enqueues a callback for asynchronous execution.
 // If the callback channel is full or the server is closed, the event is dropped.
 func (s *IClockServer) dispatchCallback(fn func()) {
-	if s.closed.Load() {
-		return
-	}
 	select {
 	case s.callbackCh <- fn:
+	case <-s.closeCh:
+		// Server is closing, drop the callback.
 	default:
 		s.logger.Printf("[Callback] WARNING: callback queue full, dropping event")
 	}
@@ -571,23 +582,29 @@ func (s *IClockServer) HandleInspect(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	s.devicesMutex.RLock()
-	defer s.devicesMutex.RUnlock()
 	snapshot := struct {
 		Devices []DeviceSnapshot `json:"devices"`
 		Count   int              `json:"count"`
 		Time    time.Time        `json:"time"`
 	}{Devices: []DeviceSnapshot{}, Time: time.Now()}
+
+	s.devicesMutex.RLock()
 	for _, d := range s.devices {
+		opts := make(map[string]string, len(d.Options))
+		for k, v := range d.Options {
+			opts[k] = v
+		}
 		snap := DeviceSnapshot{
 			Serial:       d.SerialNumber,
 			LastActivity: d.LastActivity.Format(time.RFC3339),
 			Online:       s.isDeviceOnline(d),
-			Options:      d.Options,
+			Options:      opts,
 		}
 		snapshot.Devices = append(snapshot.Devices, snap)
 	}
 	snapshot.Count = len(snapshot.Devices)
+	s.devicesMutex.RUnlock()
+
 	w.Header().Set("Content-Type", "application/json")
 	if err := json.NewEncoder(w).Encode(snapshot); err != nil {
 		http.Error(w, "failed to encode response", http.StatusInternalServerError)

--- a/iclock.go
+++ b/iclock.go
@@ -31,6 +31,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 )
 
@@ -89,6 +90,8 @@ type IClockServer struct {
 
 	callbackCh   chan func()
 	callbackDone chan struct{}
+	closeOnce    sync.Once
+	closed       atomic.Bool
 }
 
 // NewIClockServer creates a new iclock server instance.
@@ -107,22 +110,40 @@ func NewIClockServer() *IClockServer {
 
 // Close drains the callback queue and stops the worker goroutine.
 // It blocks until all pending callbacks have been executed.
+// Close is safe to call multiple times.
 func (s *IClockServer) Close() {
-	close(s.callbackCh)
-	<-s.callbackDone
+	s.closeOnce.Do(func() {
+		s.closed.Store(true)
+		close(s.callbackCh)
+		<-s.callbackDone
+	})
 }
 
 // callbackWorker processes queued callbacks sequentially.
+// Panics in user callbacks are recovered so the worker stays alive.
 func (s *IClockServer) callbackWorker() {
 	defer close(s.callbackDone)
 	for fn := range s.callbackCh {
-		fn()
+		s.safeCall(fn)
 	}
 }
 
+// safeCall executes fn, recovering from any panic.
+func (s *IClockServer) safeCall(fn func()) {
+	defer func() {
+		if r := recover(); r != nil {
+			s.logger.Printf("[Callback] panic recovered: %v", r)
+		}
+	}()
+	fn()
+}
+
 // dispatchCallback enqueues a callback for asynchronous execution.
-// If the callback channel is full the event is dropped and a warning is logged.
+// If the callback channel is full or the server is closed, the event is dropped.
 func (s *IClockServer) dispatchCallback(fn func()) {
+	if s.closed.Load() {
+		return
+	}
 	select {
 	case s.callbackCh <- fn:
 	default:
@@ -230,10 +251,10 @@ func (s *IClockServer) HandleCData(w http.ResponseWriter, r *http.Request) {
 		}
 
 		records := s.parseAttendanceRecords(string(body), serialNumber)
-		if s.OnAttendance != nil {
+		if cb := s.OnAttendance; cb != nil {
 			for _, record := range records {
 				rec := record // capture loop variable
-				s.dispatchCallback(func() { s.OnAttendance(rec) })
+				s.dispatchCallback(func() { cb(rec) })
 			}
 		}
 
@@ -253,10 +274,10 @@ func (s *IClockServer) HandleCData(w http.ResponseWriter, r *http.Request) {
 				http.Error(w, "Failed to read body", http.StatusBadRequest)
 				return
 			}
-			if len(body) > 0 && s.OnDeviceInfo != nil {
+			if cb := s.OnDeviceInfo; len(body) > 0 && cb != nil {
 				info := s.parseDeviceInfo(string(body))
 				sn := serialNumber
-				s.dispatchCallback(func() { s.OnDeviceInfo(sn, info) })
+				s.dispatchCallback(func() { cb(sn, info) })
 			}
 			if len(body) > 0 {
 				preview := string(body)
@@ -534,9 +555,9 @@ func (s *IClockServer) HandleRegistry(w http.ResponseWriter, r *http.Request) {
 			}
 		}
 		s.devicesMutex.Unlock()
-		if s.OnRegistry != nil {
+		if cb := s.OnRegistry; cb != nil {
 			sn := serialNumber
-			s.dispatchCallback(func() { s.OnRegistry(sn, info) })
+			s.dispatchCallback(func() { cb(sn, info) })
 		}
 	}
 	w.WriteHeader(http.StatusOK)

--- a/iclock.go
+++ b/iclock.go
@@ -17,6 +17,8 @@
 //   - /iclock/cdata - receives attendance logs and device data
 //   - /iclock/getrequest - handles device polling for commands
 //   - /iclock/devicecmd - receives command execution confirmations
+//
+// Call Close when the server is no longer needed to drain the callback queue.
 package zkdevicesync
 
 import (
@@ -37,7 +39,19 @@ type Device struct {
 	SerialNumber string
 	LastActivity time.Time
 	Options      map[string]string
-	Online       bool // Heartbeat status
+}
+
+// copy returns a deep copy of the Device, including its Options map.
+func (d *Device) copy() *Device {
+	opts := make(map[string]string, len(d.Options))
+	for k, v := range d.Options {
+		opts[k] = v
+	}
+	return &Device{
+		SerialNumber: d.SerialNumber,
+		LastActivity: d.LastActivity,
+		Options:      opts,
+	}
 }
 
 // AttendanceRecord represents an attendance transaction from the device
@@ -50,7 +64,19 @@ type AttendanceRecord struct {
 	SerialNumber string
 }
 
-// IClockServer manages communication with ZKTeco devices using the iclock protocol
+// DeviceSnapshot is the JSON representation of a device in the /iclock/inspect response.
+type DeviceSnapshot struct {
+	Serial       string            `json:"serial"`
+	LastActivity string            `json:"lastActivity"`
+	Online       bool              `json:"online"`
+	Options      map[string]string `json:"options"`
+}
+
+// IClockServer manages communication with ZKTeco devices using the iclock protocol.
+//
+// Callbacks (OnAttendance, OnDeviceInfo, OnRegistry) are dispatched asynchronously
+// via an internal worker goroutine so they never block device HTTP responses.
+// Call Close to drain the callback queue when the server is shutting down.
 type IClockServer struct {
 	devices      map[string]*Device
 	devicesMutex sync.RWMutex
@@ -60,14 +86,47 @@ type IClockServer struct {
 	OnDeviceInfo func(sn string, info map[string]string)
 	OnRegistry   func(sn string, info map[string]string)
 	logger       *log.Logger
+
+	callbackCh   chan func()
+	callbackDone chan struct{}
 }
 
-// NewIClockServer creates a new iclock server instance
+// NewIClockServer creates a new iclock server instance.
+// Call Close when the server is no longer needed.
 func NewIClockServer() *IClockServer {
-	return &IClockServer{
+	s := &IClockServer{
 		devices:      make(map[string]*Device),
 		commandQueue: make(map[string][]string),
 		logger:       log.Default(),
+		callbackCh:   make(chan func(), 256),
+		callbackDone: make(chan struct{}),
+	}
+	go s.callbackWorker()
+	return s
+}
+
+// Close drains the callback queue and stops the worker goroutine.
+// It blocks until all pending callbacks have been executed.
+func (s *IClockServer) Close() {
+	close(s.callbackCh)
+	<-s.callbackDone
+}
+
+// callbackWorker processes queued callbacks sequentially.
+func (s *IClockServer) callbackWorker() {
+	defer close(s.callbackDone)
+	for fn := range s.callbackCh {
+		fn()
+	}
+}
+
+// dispatchCallback enqueues a callback for asynchronous execution.
+// If the callback channel is full the event is dropped and a warning is logged.
+func (s *IClockServer) dispatchCallback(fn func()) {
+	select {
+	case s.callbackCh <- fn:
+	default:
+		s.logger.Printf("[Callback] WARNING: callback queue full, dropping event")
 	}
 }
 
@@ -81,16 +140,28 @@ func (s *IClockServer) RegisterDevice(serialNumber string) {
 			SerialNumber: serialNumber,
 			LastActivity: time.Now(),
 			Options:      make(map[string]string),
-			Online:       true,
 		}
 	}
 }
 
-// GetDevice retrieves device information
+// GetDevice retrieves a copy of device information.
+// Returns nil if the device is not registered.
 func (s *IClockServer) GetDevice(serialNumber string) *Device {
 	s.devicesMutex.RLock()
 	defer s.devicesMutex.RUnlock()
-	return s.devices[serialNumber]
+	d := s.devices[serialNumber]
+	if d == nil {
+		return nil
+	}
+	return d.copy()
+}
+
+// IsDeviceOnline reports whether the device has been active within the last 2 minutes.
+func (s *IClockServer) IsDeviceOnline(serialNumber string) bool {
+	s.devicesMutex.RLock()
+	defer s.devicesMutex.RUnlock()
+	d := s.devices[serialNumber]
+	return s.isDeviceOnline(d)
 }
 
 // QueueCommand adds a command to be sent to the device
@@ -107,18 +178,19 @@ func (s *IClockServer) GetCommands(serialNumber string) []string {
 	defer s.queueMutex.Unlock()
 
 	commands := s.commandQueue[serialNumber]
-	s.commandQueue[serialNumber] = nil // Clear the queue
+	delete(s.commandQueue, serialNumber)
 	return commands
 }
 
 // HandleCData handles the /iclock/cdata endpoint for attendance data
 func (s *IClockServer) HandleCData(w http.ResponseWriter, r *http.Request) {
-	if err := r.ParseForm(); err != nil {
-		http.Error(w, "Invalid form data", http.StatusBadRequest)
+	if r.Method != http.MethodGet && r.Method != http.MethodPost {
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
 		return
 	}
 
-	serialNumber := r.Form.Get("SN")
+	query := r.URL.Query()
+	serialNumber := query.Get("SN")
 	if serialNumber == "" {
 		http.Error(w, "Missing SN parameter", http.StatusBadRequest)
 		return
@@ -131,13 +203,13 @@ func (s *IClockServer) HandleCData(w http.ResponseWriter, r *http.Request) {
 	// Logging basic request info
 	s.logger.Printf("[iClock Protocol] %s %s - Device: %s", r.Method, r.URL.Path, serialNumber)
 	for _, k := range []string{"options", "pushver", "PushOptionsFlag", "table"} {
-		if v := r.Form.Get(k); v != "" {
+		if v := query.Get(k); v != "" {
 			s.logger.Printf("[iClock Protocol]   %s: %s", k, v)
 		}
 	}
 
 	// Handle different table types
-	table := r.Form.Get("table")
+	table := query.Get("table")
 
 	switch table {
 	case "ATTLOG":
@@ -160,7 +232,8 @@ func (s *IClockServer) HandleCData(w http.ResponseWriter, r *http.Request) {
 		records := s.parseAttendanceRecords(string(body), serialNumber)
 		if s.OnAttendance != nil {
 			for _, record := range records {
-				s.OnAttendance(record)
+				rec := record // capture loop variable
+				s.dispatchCallback(func() { s.OnAttendance(rec) })
 			}
 		}
 
@@ -174,11 +247,16 @@ func (s *IClockServer) HandleCData(w http.ResponseWriter, r *http.Request) {
 
 	default:
 		// Handle INFO or other requests
-		if r.Method == "POST" {
-			body, _ := io.ReadAll(r.Body)
+		if r.Method == http.MethodPost {
+			body, err := io.ReadAll(r.Body)
+			if err != nil {
+				http.Error(w, "Failed to read body", http.StatusBadRequest)
+				return
+			}
 			if len(body) > 0 && s.OnDeviceInfo != nil {
 				info := s.parseDeviceInfo(string(body))
-				s.OnDeviceInfo(serialNumber, info)
+				sn := serialNumber
+				s.dispatchCallback(func() { s.OnDeviceInfo(sn, info) })
 			}
 			if len(body) > 0 {
 				preview := string(body)
@@ -205,12 +283,12 @@ func (s *IClockServer) HandleCData(w http.ResponseWriter, r *http.Request) {
 
 // HandleGetRequest handles the /iclock/getrequest endpoint
 func (s *IClockServer) HandleGetRequest(w http.ResponseWriter, r *http.Request) {
-	if err := r.ParseForm(); err != nil {
-		http.Error(w, "Invalid form data", http.StatusBadRequest)
+	if r.Method != http.MethodGet {
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
 		return
 	}
 
-	serialNumber := r.Form.Get("SN")
+	serialNumber := r.URL.Query().Get("SN")
 	if serialNumber == "" {
 		http.Error(w, "Missing SN parameter", http.StatusBadRequest)
 		return
@@ -236,23 +314,28 @@ func (s *IClockServer) HandleGetRequest(w http.ResponseWriter, r *http.Request) 
 
 // HandleDeviceCmd handles the /iclock/devicecmd endpoint
 func (s *IClockServer) HandleDeviceCmd(w http.ResponseWriter, r *http.Request) {
-	if err := r.ParseForm(); err != nil {
-		http.Error(w, "Invalid form data", http.StatusBadRequest)
+	if r.Method != http.MethodPost {
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
 		return
 	}
 
-	serialNumber := r.Form.Get("SN")
+	serialNumber := r.URL.Query().Get("SN")
 	if serialNumber == "" {
 		http.Error(w, "Missing SN parameter", http.StatusBadRequest)
 		return
 	}
 
+	s.RegisterDevice(serialNumber)
 	s.updateDeviceActivity(serialNumber)
 
 	s.logger.Printf("[iClock Protocol] %s %s - Device: %s", r.Method, r.URL.Path, serialNumber)
 
 	// Device is reporting command execution result
-	body, _ := io.ReadAll(r.Body)
+	body, err := io.ReadAll(r.Body)
+	if err != nil {
+		http.Error(w, "Failed to read body", http.StatusBadRequest)
+		return
+	}
 	if len(body) > 0 {
 		preview := string(body)
 		if len(preview) > 200 {
@@ -271,9 +354,9 @@ func (s *IClockServer) updateDeviceActivity(serialNumber string) {
 	defer s.devicesMutex.Unlock()
 
 	if device, exists := s.devices[serialNumber]; exists {
+		wasOnline := s.isDeviceOnline(device)
 		device.LastActivity = time.Now()
-		if !device.Online {
-			device.Online = true
+		if !wasOnline {
 			s.logger.Printf("[Heartbeat] Device %s marked as online", serialNumber)
 		} else {
 			s.logger.Printf("[Heartbeat] Device %s activity", serialNumber)
@@ -395,14 +478,15 @@ func ParseQueryParams(urlStr string) (map[string]string, error) {
 	return params, nil
 }
 
-// ListDevices returns all registered devices
+// ListDevices returns copies of all registered devices.
+// The returned slice and Device values are safe to use without additional locking.
 func (s *IClockServer) ListDevices() []*Device {
 	s.devicesMutex.RLock()
 	defer s.devicesMutex.RUnlock()
 
 	devices := make([]*Device, 0, len(s.devices))
 	for _, device := range s.devices {
-		devices = append(devices, device)
+		devices = append(devices, device.copy())
 	}
 
 	return devices
@@ -412,11 +496,13 @@ func (s *IClockServer) ListDevices() []*Device {
 
 // HandleRegistry processes /iclock/registry requests for device registration & capabilities
 func (s *IClockServer) HandleRegistry(w http.ResponseWriter, r *http.Request) {
-	if err := r.ParseForm(); err != nil {
-		http.Error(w, "Invalid form data", http.StatusBadRequest)
+	if r.Method != http.MethodGet && r.Method != http.MethodPost {
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
 		return
 	}
-	serialNumber := r.Form.Get("SN")
+
+	query := r.URL.Query()
+	serialNumber := query.Get("SN")
 	if serialNumber == "" {
 		http.Error(w, "Missing SN parameter", http.StatusBadRequest)
 		return
@@ -425,11 +511,15 @@ func (s *IClockServer) HandleRegistry(w http.ResponseWriter, r *http.Request) {
 	s.updateDeviceActivity(serialNumber)
 	s.logger.Printf("[iClock Protocol] %s %s - Device: %s", r.Method, r.URL.Path, serialNumber)
 	for _, k := range []string{"options", "pushver", "PushOptionsFlag"} {
-		if v := r.Form.Get(k); v != "" {
+		if v := query.Get(k); v != "" {
 			s.logger.Printf("[iClock Protocol]   %s: %s", k, v)
 		}
 	}
-	body, _ := io.ReadAll(r.Body)
+	body, err := io.ReadAll(r.Body)
+	if err != nil {
+		http.Error(w, "Failed to read body", http.StatusBadRequest)
+		return
+	}
 	if len(body) > 0 {
 		preview := string(body)
 		if len(preview) > 300 {
@@ -445,7 +535,8 @@ func (s *IClockServer) HandleRegistry(w http.ResponseWriter, r *http.Request) {
 		}
 		s.devicesMutex.Unlock()
 		if s.OnRegistry != nil {
-			s.OnRegistry(serialNumber, info)
+			sn := serialNumber
+			s.dispatchCallback(func() { s.OnRegistry(sn, info) })
 		}
 	}
 	w.WriteHeader(http.StatusOK)
@@ -454,21 +545,26 @@ func (s *IClockServer) HandleRegistry(w http.ResponseWriter, r *http.Request) {
 
 // HandleInspect serves /iclock/inspect returning JSON device snapshot
 func (s *IClockServer) HandleInspect(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
 	s.devicesMutex.RLock()
 	defer s.devicesMutex.RUnlock()
 	snapshot := struct {
-		Devices []map[string]interface{} `json:"devices"`
-		Count   int                      `json:"count"`
-		Time    time.Time                `json:"time"`
-	}{Devices: []map[string]interface{}{}, Time: time.Now()}
+		Devices []DeviceSnapshot `json:"devices"`
+		Count   int              `json:"count"`
+		Time    time.Time        `json:"time"`
+	}{Devices: []DeviceSnapshot{}, Time: time.Now()}
 	for _, d := range s.devices {
-		devMap := map[string]interface{}{
-			"serial":       d.SerialNumber,
-			"lastActivity": d.LastActivity.Format(time.RFC3339),
-			"online":       s.isDeviceOnline(d),
-			"options":      d.Options,
+		snap := DeviceSnapshot{
+			Serial:       d.SerialNumber,
+			LastActivity: d.LastActivity.Format(time.RFC3339),
+			Online:       s.isDeviceOnline(d),
+			Options:      d.Options,
 		}
-		snapshot.Devices = append(snapshot.Devices, devMap)
+		snapshot.Devices = append(snapshot.Devices, snap)
 	}
 	snapshot.Count = len(snapshot.Devices)
 	w.Header().Set("Content-Type", "application/json")

--- a/iclock_test.go
+++ b/iclock_test.go
@@ -774,6 +774,84 @@ func TestAttendanceRecordSerialNumber(t *testing.T) {
 	}
 }
 
+func TestCallbackNilAfterEnqueue(t *testing.T) {
+	server := NewIClockServer()
+	defer server.Close()
+
+	received := make(chan AttendanceRecord, 1)
+	server.OnAttendance = func(record AttendanceRecord) {
+		received <- record
+	}
+
+	attendanceData := "123\t2024-01-01 08:00:00\t0\t1\t0"
+	req := httptest.NewRequest("POST", "/iclock/cdata?SN=TEST001&table=ATTLOG", bytes.NewBufferString(attendanceData))
+	w := httptest.NewRecorder()
+	server.HandleCData(w, req)
+
+	// Nil the callback after the request was handled (closure already enqueued).
+	// With the captured-local fix this must not panic.
+	server.OnAttendance = nil
+
+	select {
+	case rec := <-received:
+		if rec.UserID != "123" {
+			t.Errorf("Expected UserID 123, got %s", rec.UserID)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("Timed out waiting for attendance callback")
+	}
+}
+
+func TestCloseIdempotent(t *testing.T) {
+	server := NewIClockServer()
+	server.Close()
+	server.Close() // must not panic
+}
+
+func TestDispatchAfterClose(t *testing.T) {
+	server := NewIClockServer()
+	server.Close()
+
+	// Must not panic: dispatchCallback should detect the closed state.
+	server.dispatchCallback(func() {
+		t.Error("callback should not be executed after Close")
+	})
+}
+
+func TestCallbackPanicRecovery(t *testing.T) {
+	server := NewIClockServer()
+	defer server.Close()
+
+	received := make(chan string, 1)
+
+	// First callback panics.
+	server.OnAttendance = func(record AttendanceRecord) {
+		panic("boom")
+	}
+	req1 := httptest.NewRequest("POST", "/iclock/cdata?SN=TEST001&table=ATTLOG",
+		bytes.NewBufferString("100\t2024-01-01 08:00:00\t0\t1\t0"))
+	w1 := httptest.NewRecorder()
+	server.HandleCData(w1, req1)
+
+	// Replace with a well-behaved callback.
+	server.OnAttendance = func(record AttendanceRecord) {
+		received <- record.UserID
+	}
+	req2 := httptest.NewRequest("POST", "/iclock/cdata?SN=TEST001&table=ATTLOG",
+		bytes.NewBufferString("200\t2024-01-01 09:00:00\t0\t1\t0"))
+	w2 := httptest.NewRecorder()
+	server.HandleCData(w2, req2)
+
+	select {
+	case uid := <-received:
+		if uid != "200" {
+			t.Errorf("Expected UserID 200, got %s", uid)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("Worker did not recover from panic; second callback never arrived")
+	}
+}
+
 func BenchmarkHandleCData(b *testing.B) {
 	server := NewIClockServer()
 	defer server.Close()

--- a/iclock_test.go
+++ b/iclock_test.go
@@ -12,6 +12,7 @@ import (
 
 func TestNewIClockServer(t *testing.T) {
 	server := NewIClockServer()
+	defer server.Close()
 	if server == nil {
 		t.Fatal("NewIClockServer returned nil")
 	}
@@ -25,6 +26,7 @@ func TestNewIClockServer(t *testing.T) {
 
 func TestRegisterDevice(t *testing.T) {
 	server := NewIClockServer()
+	defer server.Close()
 	serialNumber := "TEST001"
 
 	server.RegisterDevice(serialNumber)
@@ -41,8 +43,50 @@ func TestRegisterDevice(t *testing.T) {
 	}
 }
 
+func TestGetDeviceReturnsCopy(t *testing.T) {
+	server := NewIClockServer()
+	defer server.Close()
+
+	server.RegisterDevice("COPY001")
+
+	d1 := server.GetDevice("COPY001")
+	d1.SerialNumber = "MUTATED"
+	d1.Options["injected"] = "bad"
+
+	d2 := server.GetDevice("COPY001")
+	if d2.SerialNumber != "COPY001" {
+		t.Errorf("Internal state was mutated: got SerialNumber %s", d2.SerialNumber)
+	}
+	if d2.Options["injected"] != "" {
+		t.Errorf("Internal Options was mutated: got injected=%s", d2.Options["injected"])
+	}
+}
+
+func TestListDevicesReturnsCopies(t *testing.T) {
+	server := NewIClockServer()
+	defer server.Close()
+
+	server.RegisterDevice("LD001")
+
+	devices := server.ListDevices()
+	if len(devices) != 1 {
+		t.Fatalf("Expected 1 device, got %d", len(devices))
+	}
+	devices[0].SerialNumber = "MUTATED"
+	devices[0].Options["injected"] = "bad"
+
+	fresh := server.GetDevice("LD001")
+	if fresh.SerialNumber != "LD001" {
+		t.Errorf("Internal state was mutated via ListDevices")
+	}
+	if fresh.Options["injected"] != "" {
+		t.Errorf("Internal Options was mutated via ListDevices")
+	}
+}
+
 func TestQueueAndGetCommands(t *testing.T) {
 	server := NewIClockServer()
+	defer server.Close()
 	serialNumber := "TEST001"
 
 	server.QueueCommand(serialNumber, "INFO")
@@ -66,8 +110,25 @@ func TestQueueAndGetCommands(t *testing.T) {
 	}
 }
 
+func TestGetCommandsDeletesKey(t *testing.T) {
+	server := NewIClockServer()
+	defer server.Close()
+
+	server.QueueCommand("DEL001", "INFO")
+	_ = server.GetCommands("DEL001")
+
+	server.queueMutex.RLock()
+	_, exists := server.commandQueue["DEL001"]
+	server.queueMutex.RUnlock()
+
+	if exists {
+		t.Error("Expected map key to be deleted after GetCommands, but it still exists")
+	}
+}
+
 func TestHandleCData_MissingSN(t *testing.T) {
 	server := NewIClockServer()
+	defer server.Close()
 
 	req := httptest.NewRequest("GET", "/iclock/cdata", nil)
 	w := httptest.NewRecorder()
@@ -84,19 +145,11 @@ func TestHandleCData_MissingSN(t *testing.T) {
 
 func TestHandleCData_AttendanceLog(t *testing.T) {
 	server := NewIClockServer()
-	recordsReceived := 0
+	defer server.Close()
 
+	received := make(chan AttendanceRecord, 1)
 	server.OnAttendance = func(record AttendanceRecord) {
-		recordsReceived++
-		if record.UserID != "123" {
-			t.Errorf("Expected UserID 123, got %s", record.UserID)
-		}
-		if record.Status != 0 {
-			t.Errorf("Expected Status 0, got %d", record.Status)
-		}
-		if record.VerifyMode != 1 {
-			t.Errorf("Expected VerifyMode 1, got %d", record.VerifyMode)
-		}
+		received <- record
 	}
 
 	// Simulate attendance data
@@ -109,20 +162,33 @@ func TestHandleCData_AttendanceLog(t *testing.T) {
 	if w.Code != http.StatusOK {
 		t.Errorf("Expected status 200, got %d", w.Code)
 	}
-	if recordsReceived != 1 {
-		t.Errorf("Expected 1 record received, got %d", recordsReceived)
-	}
 	if !strings.Contains(w.Body.String(), "OK") {
 		t.Errorf("Expected OK response, got: %s", w.Body.String())
+	}
+
+	select {
+	case record := <-received:
+		if record.UserID != "123" {
+			t.Errorf("Expected UserID 123, got %s", record.UserID)
+		}
+		if record.Status != 0 {
+			t.Errorf("Expected Status 0, got %d", record.Status)
+		}
+		if record.VerifyMode != 1 {
+			t.Errorf("Expected VerifyMode 1, got %d", record.VerifyMode)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("Timed out waiting for attendance callback")
 	}
 }
 
 func TestHandleCData_MultipleAttendanceRecords(t *testing.T) {
 	server := NewIClockServer()
-	recordsReceived := 0
+	defer server.Close()
 
+	received := make(chan AttendanceRecord, 2)
 	server.OnAttendance = func(record AttendanceRecord) {
-		recordsReceived++
+		received <- record
 	}
 
 	// Multiple records
@@ -132,13 +198,18 @@ func TestHandleCData_MultipleAttendanceRecords(t *testing.T) {
 
 	server.HandleCData(w, req)
 
-	if recordsReceived != 2 {
-		t.Errorf("Expected 2 records received, got %d", recordsReceived)
+	for i := 0; i < 2; i++ {
+		select {
+		case <-received:
+		case <-time.After(2 * time.Second):
+			t.Fatalf("Timed out waiting for record %d", i+1)
+		}
 	}
 }
 
 func TestHandleCData_OperationLog(t *testing.T) {
 	server := NewIClockServer()
+	defer server.Close()
 
 	req := httptest.NewRequest("POST", "/iclock/cdata?SN=TEST001&table=OPERLOG", bytes.NewBufferString("operation data"))
 	w := httptest.NewRecorder()
@@ -155,6 +226,7 @@ func TestHandleCData_OperationLog(t *testing.T) {
 
 func TestHandleCData_WithPendingCommands(t *testing.T) {
 	server := NewIClockServer()
+	defer server.Close()
 	serialNumber := "TEST001"
 
 	server.QueueCommand(serialNumber, "INFO")
@@ -174,6 +246,7 @@ func TestHandleCData_WithPendingCommands(t *testing.T) {
 
 func TestHandleGetRequest(t *testing.T) {
 	server := NewIClockServer()
+	defer server.Close()
 	serialNumber := "TEST001"
 
 	server.QueueCommand(serialNumber, "DATA QUERY USER")
@@ -193,6 +266,7 @@ func TestHandleGetRequest(t *testing.T) {
 
 func TestHandleGetRequest_NoCommands(t *testing.T) {
 	server := NewIClockServer()
+	defer server.Close()
 
 	req := httptest.NewRequest("GET", "/iclock/getrequest?SN=TEST001", nil)
 	w := httptest.NewRecorder()
@@ -209,6 +283,7 @@ func TestHandleGetRequest_NoCommands(t *testing.T) {
 
 func TestHandleDeviceCmd(t *testing.T) {
 	server := NewIClockServer()
+	defer server.Close()
 
 	req := httptest.NewRequest("POST", "/iclock/devicecmd?SN=TEST001", bytes.NewBufferString("command result"))
 	w := httptest.NewRecorder()
@@ -223,25 +298,51 @@ func TestHandleDeviceCmd(t *testing.T) {
 	}
 }
 
+func TestHandleDeviceCmd_RegistersDevice(t *testing.T) {
+	server := NewIClockServer()
+	defer server.Close()
+
+	// Device was never registered — HandleDeviceCmd should register it.
+	req := httptest.NewRequest("POST", "/iclock/devicecmd?SN=NEW001", bytes.NewBufferString("result"))
+	w := httptest.NewRecorder()
+
+	server.HandleDeviceCmd(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("Expected 200, got %d", w.Code)
+	}
+	device := server.GetDevice("NEW001")
+	if device == nil {
+		t.Fatal("Expected HandleDeviceCmd to register the device, but GetDevice returned nil")
+	}
+	if device.SerialNumber != "NEW001" {
+		t.Errorf("Expected serial NEW001, got %s", device.SerialNumber)
+	}
+}
+
 func TestServeHTTP(t *testing.T) {
 	server := NewIClockServer()
+	defer server.Close()
 
 	testCases := []struct {
 		name     string
+		method   string
 		path     string
 		wantCode int
 	}{
-		{"cdata endpoint", "/iclock/cdata?SN=TEST001", http.StatusOK},
-		{"getrequest endpoint", "/iclock/getrequest?SN=TEST001", http.StatusOK},
-		{"devicecmd endpoint", "/iclock/devicecmd?SN=TEST001", http.StatusOK},
-		{"registry endpoint", "/iclock/registry?SN=TEST001", http.StatusOK},
-		{"inspect endpoint", "/iclock/inspect", http.StatusOK},
-		{"unknown endpoint", "/iclock/unknown", http.StatusNotFound},
+		{"cdata GET", "GET", "/iclock/cdata?SN=TEST001", http.StatusOK},
+		{"cdata POST", "POST", "/iclock/cdata?SN=TEST001", http.StatusOK},
+		{"getrequest GET", "GET", "/iclock/getrequest?SN=TEST001", http.StatusOK},
+		{"devicecmd POST", "POST", "/iclock/devicecmd?SN=TEST001", http.StatusOK},
+		{"registry GET", "GET", "/iclock/registry?SN=TEST001", http.StatusOK},
+		{"registry POST", "POST", "/iclock/registry?SN=TEST001", http.StatusOK},
+		{"inspect GET", "GET", "/iclock/inspect", http.StatusOK},
+		{"unknown endpoint", "GET", "/iclock/unknown", http.StatusNotFound},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			req := httptest.NewRequest("GET", tc.path, nil)
+			req := httptest.NewRequest(tc.method, tc.path, nil)
 			w := httptest.NewRecorder()
 
 			server.ServeHTTP(w, req)
@@ -253,8 +354,41 @@ func TestServeHTTP(t *testing.T) {
 	}
 }
 
+func TestMethodNotAllowed(t *testing.T) {
+	server := NewIClockServer()
+	defer server.Close()
+
+	testCases := []struct {
+		name   string
+		method string
+		path   string
+	}{
+		{"DELETE on cdata", "DELETE", "/iclock/cdata?SN=TEST001"},
+		{"PUT on cdata", "PUT", "/iclock/cdata?SN=TEST001"},
+		{"POST on getrequest", "POST", "/iclock/getrequest?SN=TEST001"},
+		{"GET on devicecmd", "GET", "/iclock/devicecmd?SN=TEST001"},
+		{"DELETE on registry", "DELETE", "/iclock/registry?SN=TEST001"},
+		{"POST on inspect", "POST", "/iclock/inspect"},
+		{"PUT on inspect", "PUT", "/iclock/inspect"},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			req := httptest.NewRequest(tc.method, tc.path, nil)
+			w := httptest.NewRecorder()
+
+			server.ServeHTTP(w, req)
+
+			if w.Code != http.StatusMethodNotAllowed {
+				t.Errorf("Expected 405, got %d", w.Code)
+			}
+		})
+	}
+}
+
 func TestHandleRegistry_PostParsesBody(t *testing.T) {
 	server := NewIClockServer()
+	defer server.Close()
 	body := "DeviceType=acc,~DeviceName=SpeedFace,IPAddress=192.168.1.201"
 	req := httptest.NewRequest("POST", "/iclock/registry?SN=REG001", bytes.NewBufferString(body))
 	w := httptest.NewRecorder()
@@ -277,8 +411,33 @@ func TestHandleRegistry_PostParsesBody(t *testing.T) {
 	}
 }
 
+func TestHandleRegistry_Callback(t *testing.T) {
+	server := NewIClockServer()
+	defer server.Close()
+
+	received := make(chan map[string]string, 1)
+	server.OnRegistry = func(sn string, info map[string]string) {
+		received <- info
+	}
+
+	body := "DeviceType=acc"
+	req := httptest.NewRequest("POST", "/iclock/registry?SN=REG002", bytes.NewBufferString(body))
+	w := httptest.NewRecorder()
+	server.HandleRegistry(w, req)
+
+	select {
+	case info := <-received:
+		if info["DeviceType"] != "acc" {
+			t.Errorf("expected DeviceType=acc, got %s", info["DeviceType"])
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("Timed out waiting for OnRegistry callback")
+	}
+}
+
 func TestHandleInspect_JSON(t *testing.T) {
 	server := NewIClockServer()
+	defer server.Close()
 	server.RegisterDevice("A1")
 	// Mark old activity to test offline
 	server.devicesMutex.Lock()
@@ -295,10 +454,7 @@ func TestHandleInspect_JSON(t *testing.T) {
 		t.Errorf("expected JSON content-type, got %s", ct)
 	}
 	var payload struct {
-		Devices []struct {
-			Serial string `json:"serial"`
-			Online bool   `json:"online"`
-		} `json:"devices"`
+		Devices []DeviceSnapshot `json:"devices"`
 	}
 	if err := json.Unmarshal(w.Body.Bytes(), &payload); err != nil {
 		t.Fatalf("invalid json: %v", err)
@@ -311,8 +467,33 @@ func TestHandleInspect_JSON(t *testing.T) {
 	}
 }
 
+func TestIsDeviceOnline(t *testing.T) {
+	server := NewIClockServer()
+	defer server.Close()
+
+	// Non-existent device
+	if server.IsDeviceOnline("GHOST") {
+		t.Error("Expected false for non-existent device")
+	}
+
+	server.RegisterDevice("ONLINE001")
+	if !server.IsDeviceOnline("ONLINE001") {
+		t.Error("Expected newly registered device to be online")
+	}
+
+	// Simulate stale activity
+	server.devicesMutex.Lock()
+	server.devices["ONLINE001"].LastActivity = time.Now().Add(-5 * time.Minute)
+	server.devicesMutex.Unlock()
+
+	if server.IsDeviceOnline("ONLINE001") {
+		t.Error("Expected device with stale activity to be offline")
+	}
+}
+
 func TestParseRegistryBody(t *testing.T) {
 	server := NewIClockServer()
+	defer server.Close()
 	body := "Key1=Val1, ~Key2=Val2,~Key3=Val3"
 	info := server.parseRegistryBody(body)
 	if info["Key1"] != "Val1" || info["Key2"] != "Val2" || info["Key3"] != "Val3" {
@@ -322,6 +503,7 @@ func TestParseRegistryBody(t *testing.T) {
 
 func TestParseAttendanceRecords(t *testing.T) {
 	server := NewIClockServer()
+	defer server.Close()
 
 	testCases := []struct {
 		name     string
@@ -391,6 +573,7 @@ func TestParseAttendanceRecords(t *testing.T) {
 
 func TestParseDeviceInfo(t *testing.T) {
 	server := NewIClockServer()
+	defer server.Close()
 
 	data := "DeviceName=ZKDevice\nSerialNumber=TEST001\nFirmwareVersion=1.0.0"
 	info := server.parseDeviceInfo(data)
@@ -408,6 +591,7 @@ func TestParseDeviceInfo(t *testing.T) {
 
 func TestSendCommand(t *testing.T) {
 	server := NewIClockServer()
+	defer server.Close()
 	serialNumber := "TEST001"
 
 	server.SendCommand(serialNumber, "INFO")
@@ -423,6 +607,7 @@ func TestSendCommand(t *testing.T) {
 
 func TestSendDataCommand(t *testing.T) {
 	server := NewIClockServer()
+	defer server.Close()
 	serialNumber := "TEST001"
 
 	server.SendDataCommand(serialNumber, "USER", "user data")
@@ -441,6 +626,7 @@ func TestSendDataCommand(t *testing.T) {
 
 func TestSendInfoCommand(t *testing.T) {
 	server := NewIClockServer()
+	defer server.Close()
 	serialNumber := "TEST001"
 
 	server.SendInfoCommand(serialNumber)
@@ -475,6 +661,7 @@ func TestParseQueryParams(t *testing.T) {
 
 func TestListDevices(t *testing.T) {
 	server := NewIClockServer()
+	defer server.Close()
 
 	server.RegisterDevice("TEST001")
 	server.RegisterDevice("TEST002")
@@ -500,6 +687,7 @@ func TestListDevices(t *testing.T) {
 
 func TestUpdateDeviceActivity(t *testing.T) {
 	server := NewIClockServer()
+	defer server.Close()
 	serialNumber := "TEST001"
 
 	server.RegisterDevice(serialNumber)
@@ -521,6 +709,7 @@ func TestUpdateDeviceActivity(t *testing.T) {
 
 func TestConcurrentAccess(t *testing.T) {
 	server := NewIClockServer()
+	defer server.Close()
 	serialNumber := "TEST001"
 
 	done := make(chan bool)
@@ -561,11 +750,12 @@ func TestConcurrentAccess(t *testing.T) {
 
 func TestAttendanceRecordSerialNumber(t *testing.T) {
 	server := NewIClockServer()
+	defer server.Close()
 	serialNumber := "TEST001"
 
-	var receivedRecord AttendanceRecord
+	received := make(chan AttendanceRecord, 1)
 	server.OnAttendance = func(record AttendanceRecord) {
-		receivedRecord = record
+		received <- record
 	}
 
 	attendanceData := "123\t2024-01-01 08:00:00\t0\t1\t0"
@@ -574,13 +764,19 @@ func TestAttendanceRecordSerialNumber(t *testing.T) {
 
 	server.HandleCData(w, req)
 
-	if receivedRecord.SerialNumber != serialNumber {
-		t.Errorf("Expected SerialNumber %s, got %s", serialNumber, receivedRecord.SerialNumber)
+	select {
+	case record := <-received:
+		if record.SerialNumber != serialNumber {
+			t.Errorf("Expected SerialNumber %s, got %s", serialNumber, record.SerialNumber)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("Timed out waiting for attendance callback")
 	}
 }
 
 func BenchmarkHandleCData(b *testing.B) {
 	server := NewIClockServer()
+	defer server.Close()
 	attendanceData := "123\t2024-01-01 08:00:00\t0\t1\t0"
 
 	for i := 0; i < b.N; i++ {
@@ -592,6 +788,7 @@ func BenchmarkHandleCData(b *testing.B) {
 
 func BenchmarkParseAttendanceRecords(b *testing.B) {
 	server := NewIClockServer()
+	defer server.Close()
 	data := "123\t2024-01-01 08:00:00\t0\t1\t0\n456\t2024-01-01 17:00:00\t1\t1\t0\n789\t2024-01-01 12:00:00\t2\t1\t0"
 
 	for i := 0; i < b.N; i++ {


### PR DESCRIPTION
High Impact Fixes
- State safety — GetDevice and ListDevices now return deep copies (Device.copy()), preventing callers from mutating internal server state
- Device lifecycle — HandleDeviceCmd now registers the device before updating activity, matching all other handlers
- Body read error handling — All io.ReadAll(r.Body) call sites now check the error and return 400 on failure
- HTTP method enforcement — Each endpoint validates the HTTP method and returns 405 Method Not Allowed for unsupported ones (cdata: GET/POST, getrequest: GET, devicecmd: POST, registry: GET/POST, inspect: GET)
- ParseForm removal — All handlers use r.URL.Query() instead of r.ParseForm(), fixing a bug where ParseForm consumed the request body on ATTLOG POST requests
- Queue cleanup — GetCommands uses delete() instead of assigning nil, preventing unbounded map key accumulation
Improvements
- Online state — Removed Device.Online field; added IsDeviceOnline(sn) method using time-based liveness check (2-minute threshold)
- Typed inspect response — Added DeviceSnapshot struct, replacing []map[string]interface{} in the /iclock/inspect endpoint
- Async callbacks — Callbacks (OnAttendance, OnDeviceInfo, OnRegistry) are now dispatched via a buffered channel (cap 256) + worker goroutine, so they never block device HTTP responses. Includes panic recovery to keep the worker alive
- Graceful shutdown — Added Close() method (idempotent via sync.Once) that drains the callback queue