### PR TITLE
Add commands example, device cap, eviction worker, and CLI device pre-registration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,4 @@ Thumbs.db
 /build/
 /basic
 /database
+/commands

--- a/README.md
+++ b/README.md
@@ -96,7 +96,8 @@ func statusString(status int) string {
 
 ```go
 // Defaults: slog.Default() logger, 10 MB body limit, 256 callback buffer,
-// 2-minute online threshold, 1-second dispatch timeout.
+// 2-minute online threshold, 1-second dispatch timeout, 1000 max devices,
+// 24h device eviction timeout.
 server := zkadms.NewADMSServer()
 defer server.Close()
 ```
@@ -128,8 +129,11 @@ defer server.Close()
 | `WithOnlineThreshold` | 2 min | Duration before a device is considered offline |
 | `WithDispatchTimeout` | 1 sec | Max block time when callback queue is full |
 | `WithBaseContext` | `context.Background()` | Parent context for callbacks |
-| `WithMaxDevices` | 0 (unlimited) | Max registered devices; returns `ErrMaxDevicesReached` |
+| `WithMaxDevices` | 1000 | Max registered devices; use `WithUnlimitedDevices()` to remove the cap |
+| `WithUnlimitedDevices` | — | Remove the device registration limit (use with caution) |
 | `WithMaxCommandsPerDevice` | 0 (unlimited) | Max queued commands per device; returns `ErrCommandQueueFull` |
+| `WithDeviceEvictionInterval` | 5 min | How often the eviction worker checks for stale devices |
+| `WithDeviceEvictionTimeout` | 24 hours | Inactivity duration before a device is automatically evicted |
 | `WithEnableInspect` | disabled | Enable the `/iclock/inspect` debug endpoint |
 | `WithOnAttendance` | nil | Attendance record callback |
 | `WithOnDeviceInfo` | nil | Device info callback |
@@ -397,8 +401,11 @@ Creates a new ADMS server instance configured with the given options.
 | `WithOnlineThreshold(time.Duration)` | Set device online threshold |
 | `WithDispatchTimeout(time.Duration)` | Set callback dispatch timeout |
 | `WithBaseContext(context.Context)` | Set parent context |
-| `WithMaxDevices(int)` | Set max registered devices |
+| `WithMaxDevices(int)` | Set max registered devices (default 1000) |
+| `WithUnlimitedDevices()` | Remove the device registration limit |
 | `WithMaxCommandsPerDevice(int)` | Set max command queue depth per device |
+| `WithDeviceEvictionInterval(time.Duration)` | Set stale-device check interval |
+| `WithDeviceEvictionTimeout(time.Duration)` | Set inactivity threshold for eviction |
 | `WithEnableInspect()` | Enable `/iclock/inspect` in ServeHTTP router |
 | `WithOnAttendance(func(context.Context, AttendanceRecord))` | Set attendance callback |
 | `WithOnDeviceInfo(func(context.Context, string, map[string]string))` | Set device info callback |
@@ -414,6 +421,7 @@ Creates a new ADMS server instance configured with the given options.
 | `IsDeviceOnline(serialNumber string) bool` | Check if a device is online |
 | `QueueCommand(serialNumber, command string) error` | Queue a command; respects per-device limit |
 | `DrainCommands(serialNumber string) []string` | Drain and return all pending commands |
+| `PendingCommandsCount(serialNumber string) int` | Return the number of queued commands without draining |
 | `SendInfoCommand(serialNumber string) error` | Queue an INFO command |
 | `SendDataCommand(serialNumber, table, data string) error` | Queue a DATA QUERY command |
 | `ListDevices() []*Device` | List all registered devices (returns copies) |

--- a/README.md
+++ b/README.md
@@ -329,6 +329,7 @@ Use `zkadms.VerifyModeName(mode)` to resolve any value to a human-readable label
 See the [examples](./examples) directory for complete examples:
 
 - **[basic](./examples/basic)** - Simple server with status endpoint
+- **[commands](./examples/commands)** - Device command management via REST API
 - **[database](./examples/database)** - Integration with database storage
 
 ### Running Examples

--- a/adms.go
+++ b/adms.go
@@ -875,6 +875,14 @@ func (s *ADMSServer) DrainCommands(serialNumber string) []string {
 	return commands
 }
 
+// PendingCommandsCount returns the number of queued commands for a device
+// without modifying the queue.
+func (s *ADMSServer) PendingCommandsCount(serialNumber string) int {
+	s.queueMutex.RLock()
+	defer s.queueMutex.RUnlock()
+	return len(s.commandQueue[serialNumber])
+}
+
 // GetCommands retrieves and removes pending commands for a device.
 //
 // Deprecated: Use [ADMSServer.DrainCommands] instead. GetCommands is

--- a/adms.go
+++ b/adms.go
@@ -54,6 +54,18 @@ const (
 	// when the callback channel is full before dropping the event.
 	defaultDispatchTimeout = 1 * time.Second
 
+	// defaultMaxDevices is the default maximum number of registered devices.
+	// Use [WithMaxDevices] to override or [WithUnlimitedDevices] to remove the cap.
+	defaultMaxDevices = 1000
+
+	// defaultDeviceEvictionInterval is how often the eviction worker checks for
+	// stale devices.
+	defaultDeviceEvictionInterval = 5 * time.Minute
+
+	// defaultDeviceEvictionTimeout is the inactivity duration after which a
+	// device is automatically evicted.
+	defaultDeviceEvictionTimeout = 24 * time.Hour
+
 	// maxSerialNumberLength is the maximum allowed length for a device serial number.
 	maxSerialNumberLength = 64
 
@@ -264,12 +276,22 @@ func WithBaseContext(ctx context.Context) Option {
 // WithMaxDevices sets the maximum number of devices that can be registered
 // simultaneously. When the limit is reached, new device registrations from
 // HTTP requests are rejected with 503 Service Unavailable.
-// A value of 0 (the default) means unlimited.
+// The default is 1000. Use [WithUnlimitedDevices] to remove the limit.
 func WithMaxDevices(n int) Option {
 	return func(s *ADMSServer) {
 		if n >= 0 {
 			s.maxDevices = n
 		}
+	}
+}
+
+// WithUnlimitedDevices removes the default device registration limit.
+// By default the server allows up to 1000 devices; this option sets the
+// limit to 0 (unlimited). Use with caution: without a limit, a flood of
+// requests with unique serial numbers can grow the device map without bound.
+func WithUnlimitedDevices() Option {
+	return func(s *ADMSServer) {
+		s.maxDevices = 0
 	}
 }
 
@@ -293,6 +315,30 @@ func WithMaxCommandsPerDevice(n int) Option {
 func WithEnableInspect() Option {
 	return func(s *ADMSServer) {
 		s.enableInspect = true
+	}
+}
+
+// WithDeviceEvictionInterval sets how often the background eviction worker
+// checks for stale devices. The default is 5 minutes. The eviction worker
+// removes devices that have been inactive longer than the eviction timeout
+// (see [WithDeviceEvictionTimeout]) and cleans up their command queues.
+func WithDeviceEvictionInterval(d time.Duration) Option {
+	return func(s *ADMSServer) {
+		if d > 0 {
+			s.deviceEvictionInterval = d
+		}
+	}
+}
+
+// WithDeviceEvictionTimeout sets the inactivity duration after which a
+// device is automatically removed by the background eviction worker.
+// The default is 24 hours. When a device is evicted, its pending command
+// queue is also cleaned up.
+func WithDeviceEvictionTimeout(d time.Duration) Option {
+	return func(s *ADMSServer) {
+		if d > 0 {
+			s.deviceEvictionTimeout = d
+		}
 	}
 }
 
@@ -380,12 +426,16 @@ type ADMSServer struct {
 	maxCommandsPerDevice int  // 0 = unlimited
 	enableInspect        bool // false = /iclock/inspect not routed in ServeHTTP
 
+	deviceEvictionInterval time.Duration // how often the eviction worker runs
+	deviceEvictionTimeout  time.Duration // inactivity threshold for eviction
+
 	baseCtx       context.Context
 	baseCtxCancel context.CancelFunc
 
 	callbackCh   chan func()
 	callbackMu   sync.RWMutex // guards callbackCh close in coordination with dispatchers
 	callbackDone chan struct{}
+	evictionDone chan struct{}
 	closeCh      chan struct{}
 	closeOnce    sync.Once
 }
@@ -403,15 +453,19 @@ type ADMSServer struct {
 // callbacks and stop the worker.
 func NewADMSServer(opts ...Option) *ADMSServer {
 	s := &ADMSServer{
-		devices:            make(map[string]*Device),
-		commandQueue:       make(map[string][]string),
-		logger:             slog.Default(),
-		maxBodySize:        defaultMaxBodySize,
-		callbackBufferSize: defaultCallbackBufferSize,
-		onlineThreshold:    defaultOnlineThreshold,
-		dispatchTimeout:    defaultDispatchTimeout,
-		callbackDone:       make(chan struct{}),
-		closeCh:            make(chan struct{}),
+		devices:                make(map[string]*Device),
+		commandQueue:           make(map[string][]string),
+		logger:                 slog.Default(),
+		maxBodySize:            defaultMaxBodySize,
+		maxDevices:             defaultMaxDevices,
+		callbackBufferSize:     defaultCallbackBufferSize,
+		onlineThreshold:        defaultOnlineThreshold,
+		dispatchTimeout:        defaultDispatchTimeout,
+		deviceEvictionInterval: defaultDeviceEvictionInterval,
+		deviceEvictionTimeout:  defaultDeviceEvictionTimeout,
+		callbackDone:           make(chan struct{}),
+		evictionDone:           make(chan struct{}),
+		closeCh:                make(chan struct{}),
 	}
 	for _, opt := range opts {
 		opt(s)
@@ -425,18 +479,23 @@ func NewADMSServer(opts ...Option) *ADMSServer {
 
 	s.callbackCh = make(chan func(), s.callbackBufferSize)
 	go s.callbackWorker()
+	go s.evictionWorker()
 	return s
 }
 
 // Close drains the callback queue and stops the worker goroutine.
-// It blocks until all pending callbacks have been executed.
+// It blocks until all pending callbacks have been executed and the
+// eviction worker has exited.
 // Close is safe to call multiple times.
 func (s *ADMSServer) Close() {
 	s.closeOnce.Do(func() {
 		// Cancel the base context so callbacks see cancellation.
 		s.baseCtxCancel()
-		// Signal all dispatchers to stop accepting new callbacks.
+		// Signal all dispatchers and the eviction worker to stop.
 		close(s.closeCh)
+		// Wait for the eviction worker to exit before tearing down the
+		// callback pipeline, so no late eviction log races with closure.
+		<-s.evictionDone
 		// Wait for any in-flight dispatchCallback calls to finish sending.
 		// RLock holders (dispatchers) will see closeCh and exit their select.
 		s.callbackMu.Lock()
@@ -466,6 +525,53 @@ func (s *ADMSServer) safeCall(fn func()) {
 		}
 	}()
 	fn()
+}
+
+// evictionWorker periodically removes devices that have been inactive longer
+// than the configured eviction timeout. It also cleans up pending commands for
+// evicted devices. The worker exits when closeCh is closed.
+func (s *ADMSServer) evictionWorker() {
+	defer close(s.evictionDone)
+	ticker := time.NewTicker(s.deviceEvictionInterval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-s.closeCh:
+			return
+		case <-ticker.C:
+			s.evictStaleDevices()
+		}
+	}
+}
+
+// evictStaleDevices removes devices inactive longer than the eviction timeout
+// and cleans up their command queues. Lock ordering: devicesMutex first, then
+// queueMutex — never held simultaneously.
+func (s *ADMSServer) evictStaleDevices() {
+	// Phase 1: collect stale serial numbers under devicesMutex.
+	var stale []string
+	now := time.Now()
+	s.devicesMutex.Lock()
+	for sn, d := range s.devices {
+		if now.Sub(d.LastActivity) > s.deviceEvictionTimeout {
+			stale = append(stale, sn)
+			delete(s.devices, sn)
+		}
+	}
+	s.devicesMutex.Unlock()
+
+	if len(stale) == 0 {
+		return
+	}
+
+	// Phase 2: clean command queues under queueMutex.
+	s.queueMutex.Lock()
+	for _, sn := range stale {
+		delete(s.commandQueue, sn)
+	}
+	s.queueMutex.Unlock()
+
+	s.logger.Info("evicted stale devices", "count", len(stale))
 }
 
 // readBody reads the request body with a size limit enforced by http.MaxBytesReader.

--- a/adms_test.go
+++ b/adms_test.go
@@ -1614,6 +1614,32 @@ func TestGetCommands_BackwardCompat(t *testing.T) {
 	}
 }
 
+func TestPendingCommandsCount(t *testing.T) {
+	server := NewADMSServer()
+	defer server.Close()
+
+	// Zero for unknown device.
+	if n := server.PendingCommandsCount("NODEV"); n != 0 {
+		t.Errorf("expected 0 pending commands for unknown device, got %d", n)
+	}
+
+	// Queue a few commands and verify count without draining.
+	for _, cmd := range []string{"INFO", "CHECK", "REBOOT"} {
+		if err := server.QueueCommand("COUNT001", cmd); err != nil {
+			t.Fatalf("QueueCommand(%q) failed: %v", cmd, err)
+		}
+	}
+	if n := server.PendingCommandsCount("COUNT001"); n != 3 {
+		t.Errorf("expected 3 pending commands, got %d", n)
+	}
+
+	// Drain one command and verify count decreases.
+	_ = server.DrainCommands("COUNT001")
+	if n := server.PendingCommandsCount("COUNT001"); n != 0 {
+		t.Errorf("expected 0 pending commands after drain, got %d", n)
+	}
+}
+
 func TestFunctionalOption_OverridesDeprecatedField(t *testing.T) {
 	// When both the deprecated field and functional option are set,
 	// the functional option should take precedence.

--- a/adms_test.go
+++ b/adms_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"log/slog"
 	"net/http"
 	"net/http/httptest"
@@ -1664,6 +1665,15 @@ func TestNewADMSServer_Defaults(t *testing.T) {
 	if cap(server.callbackCh) != defaultCallbackBufferSize {
 		t.Errorf("expected default callbackCh capacity %d, got %d", defaultCallbackBufferSize, cap(server.callbackCh))
 	}
+	if server.maxDevices != defaultMaxDevices {
+		t.Errorf("expected default maxDevices %d, got %d", defaultMaxDevices, server.maxDevices)
+	}
+	if server.deviceEvictionInterval != defaultDeviceEvictionInterval {
+		t.Errorf("expected default deviceEvictionInterval %v, got %v", defaultDeviceEvictionInterval, server.deviceEvictionInterval)
+	}
+	if server.deviceEvictionTimeout != defaultDeviceEvictionTimeout {
+		t.Errorf("expected default deviceEvictionTimeout %v, got %v", defaultDeviceEvictionTimeout, server.deviceEvictionTimeout)
+	}
 }
 
 func TestWithLogger_NilIgnored(t *testing.T) {
@@ -1840,8 +1850,8 @@ func TestWithMaxDevices_NegativeIgnored(t *testing.T) {
 	server := NewADMSServer(WithMaxDevices(-5))
 	defer server.Close()
 
-	if server.maxDevices != 0 {
-		t.Errorf("expected negative to be ignored (0), got %d", server.maxDevices)
+	if server.maxDevices != defaultMaxDevices {
+		t.Errorf("expected negative to be ignored (default %d), got %d", defaultMaxDevices, server.maxDevices)
 	}
 }
 
@@ -2031,5 +2041,165 @@ func TestRegisterDevice_Idempotent(t *testing.T) {
 	devices := server.ListDevices()
 	if len(devices) != 1 {
 		t.Errorf("expected 1 device after duplicate register, got %d", len(devices))
+	}
+}
+
+// --- Eviction worker tests ---
+
+func TestEvictionWorker_RemovesStaleDevices(t *testing.T) {
+	server := NewADMSServer(
+		WithDeviceEvictionInterval(50*time.Millisecond),
+		WithDeviceEvictionTimeout(100*time.Millisecond),
+	)
+	defer server.Close()
+
+	if err := server.RegisterDevice("STALE01"); err != nil {
+		t.Fatalf("RegisterDevice failed: %v", err)
+	}
+
+	// Backdate the device's LastActivity so it appears stale.
+	server.devicesMutex.Lock()
+	server.devices["STALE01"].LastActivity = time.Now().Add(-time.Hour)
+	server.devicesMutex.Unlock()
+
+	// Wait long enough for at least one eviction cycle.
+	time.Sleep(200 * time.Millisecond)
+
+	if d := server.GetDevice("STALE01"); d != nil {
+		t.Error("expected stale device to be evicted, but it still exists")
+	}
+}
+
+func TestEvictionWorker_KeepsActiveDevices(t *testing.T) {
+	server := NewADMSServer(
+		WithDeviceEvictionInterval(50*time.Millisecond),
+		WithDeviceEvictionTimeout(10*time.Second),
+	)
+	defer server.Close()
+
+	if err := server.RegisterDevice("ACTIVE01"); err != nil {
+		t.Fatalf("RegisterDevice failed: %v", err)
+	}
+
+	// Wait for a few eviction cycles.
+	time.Sleep(200 * time.Millisecond)
+
+	if d := server.GetDevice("ACTIVE01"); d == nil {
+		t.Error("expected active device to survive eviction, but it was removed")
+	}
+}
+
+func TestEvictionWorker_CleansCommandQueue(t *testing.T) {
+	server := NewADMSServer(
+		WithDeviceEvictionInterval(50*time.Millisecond),
+		WithDeviceEvictionTimeout(100*time.Millisecond),
+	)
+	defer server.Close()
+
+	if err := server.RegisterDevice("CMDDEV01"); err != nil {
+		t.Fatalf("RegisterDevice failed: %v", err)
+	}
+	if err := server.QueueCommand("CMDDEV01", "REBOOT"); err != nil {
+		t.Fatalf("QueueCommand failed: %v", err)
+	}
+
+	// Backdate so device is stale.
+	server.devicesMutex.Lock()
+	server.devices["CMDDEV01"].LastActivity = time.Now().Add(-time.Hour)
+	server.devicesMutex.Unlock()
+
+	time.Sleep(200 * time.Millisecond)
+
+	// Device should be gone.
+	if d := server.GetDevice("CMDDEV01"); d != nil {
+		t.Error("expected stale device to be evicted")
+	}
+	// Command queue should be cleaned up.
+	cmds := server.DrainCommands("CMDDEV01")
+	if len(cmds) != 0 {
+		t.Errorf("expected empty command queue after eviction, got %d commands", len(cmds))
+	}
+}
+
+func TestEvictionWorker_StopsOnClose(t *testing.T) {
+	server := NewADMSServer(
+		WithDeviceEvictionInterval(10*time.Millisecond),
+		WithDeviceEvictionTimeout(time.Hour),
+	)
+
+	// Close should return promptly, meaning the eviction worker exited.
+	done := make(chan struct{})
+	go func() {
+		server.Close()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+		// Success: Close returned.
+	case <-time.After(2 * time.Second):
+		t.Fatal("Close did not return within 2 seconds; eviction worker may be stuck")
+	}
+}
+
+func TestWithDeviceEvictionInterval(t *testing.T) {
+	server := NewADMSServer(WithDeviceEvictionInterval(42 * time.Second))
+	defer server.Close()
+
+	if server.deviceEvictionInterval != 42*time.Second {
+		t.Errorf("expected 42s, got %v", server.deviceEvictionInterval)
+	}
+}
+
+func TestWithDeviceEvictionInterval_ZeroIgnored(t *testing.T) {
+	server := NewADMSServer(WithDeviceEvictionInterval(0))
+	defer server.Close()
+
+	if server.deviceEvictionInterval != defaultDeviceEvictionInterval {
+		t.Errorf("expected default %v, got %v", defaultDeviceEvictionInterval, server.deviceEvictionInterval)
+	}
+}
+
+func TestWithDeviceEvictionTimeout(t *testing.T) {
+	server := NewADMSServer(WithDeviceEvictionTimeout(12 * time.Hour))
+	defer server.Close()
+
+	if server.deviceEvictionTimeout != 12*time.Hour {
+		t.Errorf("expected 12h, got %v", server.deviceEvictionTimeout)
+	}
+}
+
+func TestWithDeviceEvictionTimeout_ZeroIgnored(t *testing.T) {
+	server := NewADMSServer(WithDeviceEvictionTimeout(0))
+	defer server.Close()
+
+	if server.deviceEvictionTimeout != defaultDeviceEvictionTimeout {
+		t.Errorf("expected default %v, got %v", defaultDeviceEvictionTimeout, server.deviceEvictionTimeout)
+	}
+}
+
+func TestWithUnlimitedDevices(t *testing.T) {
+	server := NewADMSServer(WithUnlimitedDevices())
+	defer server.Close()
+
+	if server.maxDevices != 0 {
+		t.Errorf("expected unlimited (0), got %d", server.maxDevices)
+	}
+
+	// Should accept many devices without error.
+	for i := range 50 {
+		sn := fmt.Sprintf("UNLIM%03d", i)
+		if err := server.RegisterDevice(sn); err != nil {
+			t.Fatalf("RegisterDevice(%s) failed: %v", sn, err)
+		}
+	}
+}
+
+func TestDefaultMaxDevices(t *testing.T) {
+	server := NewADMSServer()
+	defer server.Close()
+
+	if server.maxDevices != 1000 {
+		t.Errorf("expected default maxDevices=1000, got %d", server.maxDevices)
 	}
 }

--- a/examples/basic/main.go
+++ b/examples/basic/main.go
@@ -1,6 +1,11 @@
 // Command basic demonstrates a minimal ZKTeco ADMS server with device
 // status and command-sending endpoints.
 //
+// SECURITY WARNING: This example does NOT include any authentication or
+// authorization. All endpoints (/status, /command) are publicly accessible.
+// In a production deployment you MUST add authentication middleware (e.g.
+// API keys, OAuth2, mTLS) before exposing these routes to a network.
+//
 // Run with:
 //
 //	go run ./examples/basic
@@ -98,6 +103,8 @@ func commandHandler(server *zkadms.ADMSServer) http.Handler {
 func newMux(server *zkadms.ADMSServer) *http.ServeMux {
 	mux := http.NewServeMux()
 	mux.Handle("/iclock/", logMiddleware(server))
+	// WARNING: These routes have no authentication. Add auth middleware
+	// before deploying to production.
 	mux.Handle("/status", logMiddleware(statusHandler(server)))
 	mux.Handle("/command", logMiddleware(commandHandler(server)))
 	return mux

--- a/examples/basic/main_test.go
+++ b/examples/basic/main_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -503,5 +504,135 @@ func TestRun_InvalidAddr(t *testing.T) {
 	err := run(ctx, ":-1")
 	if err == nil {
 		t.Fatal("expected error for invalid address, got nil")
+	}
+}
+
+// TestRun_ExercisesCallbacks starts the server via run() and sends simulated
+// ADMS device traffic to exercise the attendance, device-info, and registry
+// callbacks wired inside run().
+func TestRun_ExercisesCallbacks(t *testing.T) {
+	// Use a listener so we know the actual port.
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("failed to create listener: %v", err)
+	}
+	addr := ln.Addr().String()
+	ln.Close() // free the port for run()
+
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- run(ctx, addr)
+	}()
+
+	// Wait for server to start.
+	time.Sleep(100 * time.Millisecond)
+
+	base := "http://" + addr
+
+	// 1. Send attendance data — triggers WithOnAttendance callback.
+	attendanceData := "USER001\t2026-03-20 09:00:00\t0\t1\t0\tWC1"
+	resp, err := http.Post(base+"/iclock/cdata?SN=DEVICE001&table=ATTLOG",
+		"text/plain", strings.NewReader(attendanceData))
+	if err != nil {
+		t.Fatalf("POST attendance failed: %v", err)
+	}
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("expected 200 for attendance POST, got %d", resp.StatusCode)
+	}
+
+	// 2. Send device info — triggers WithOnDeviceInfo callback.
+	infoData := "FWVersion=Ver 6.60\nDeviceName=ZK-F22"
+	resp, err = http.Post(base+"/iclock/cdata?SN=DEVICE001",
+		"text/plain", strings.NewReader(infoData))
+	if err != nil {
+		t.Fatalf("POST device info failed: %v", err)
+	}
+	resp.Body.Close()
+
+	// 3. Send registry data — triggers WithOnRegistry callback.
+	//    Registry body uses comma-separated key=value pairs.
+	registryData := "UserCount=50,FPCount=100,AttCount=5000,FWVersion=Ver 6.60,IPAddress=192.168.1.201"
+	resp, err = http.Post(base+"/iclock/registry?SN=DEVICE001",
+		"text/plain", strings.NewReader(registryData))
+	if err != nil {
+		t.Fatalf("POST registry failed: %v", err)
+	}
+	resp.Body.Close()
+
+	// 4. Verify /status shows the devices.
+	resp, err = http.Get(base + "/status")
+	if err != nil {
+		t.Fatalf("GET /status failed: %v", err)
+	}
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("expected 200 for /status, got %d", resp.StatusCode)
+	}
+
+	// Give callbacks time to be processed.
+	time.Sleep(100 * time.Millisecond)
+
+	cancel()
+
+	select {
+	case err := <-errCh:
+		if err != nil {
+			t.Fatalf("run returned unexpected error: %v", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("run did not return within 5s after context cancellation")
+	}
+}
+
+// TestRun_RegistryCallbackManyEntries exercises the registry callback's
+// truncation logic (shown >= 8 break).
+func TestRun_RegistryCallbackManyEntries(t *testing.T) {
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("failed to create listener: %v", err)
+	}
+	addr := ln.Addr().String()
+	ln.Close()
+
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- run(ctx, addr)
+	}()
+
+	time.Sleep(100 * time.Millisecond)
+
+	base := "http://" + addr
+
+	// Send registry data with more than 8 key-value pairs to trigger the break.
+	// Registry body uses comma-separated key=value pairs.
+	var parts []string
+	for i := range 15 {
+		parts = append(parts, fmt.Sprintf("Key%d=Value%d", i, i))
+	}
+	registryData := strings.Join(parts, ",")
+	resp, err := http.Post(base+"/iclock/registry?SN=DEVICE001",
+		"text/plain", strings.NewReader(registryData))
+	if err != nil {
+		t.Fatalf("POST registry failed: %v", err)
+	}
+	resp.Body.Close()
+
+	time.Sleep(100 * time.Millisecond)
+	cancel()
+
+	select {
+	case err := <-errCh:
+		if err != nil {
+			t.Fatalf("run returned unexpected error: %v", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("run did not return within 5s")
 	}
 }

--- a/examples/basic/main_test.go
+++ b/examples/basic/main_test.go
@@ -527,10 +527,23 @@ func TestRun_ExercisesCallbacks(t *testing.T) {
 		errCh <- run(ctx, addr)
 	}()
 
-	// Wait for server to start.
-	time.Sleep(100 * time.Millisecond)
-
+	// Wait for server to start using a readiness loop instead of a fixed sleep.
 	base := "http://" + addr
+	{
+		client := http.Client{Timeout: 500 * time.Millisecond}
+		deadline := time.Now().Add(5 * time.Second)
+		for {
+			if time.Now().After(deadline) {
+				t.Fatalf("server did not become ready within timeout")
+			}
+			resp, err := client.Get(base + "/status")
+			if err == nil {
+				resp.Body.Close()
+				break
+			}
+			time.Sleep(50 * time.Millisecond)
+		}
+	}
 
 	// 1. Send attendance data — triggers WithOnAttendance callback.
 	attendanceData := "USER001\t2026-03-20 09:00:00\t0\t1\t0\tWC1"

--- a/examples/basic/main_test.go
+++ b/examples/basic/main_test.go
@@ -612,7 +612,7 @@ func TestRun_RegistryCallbackManyEntries(t *testing.T) {
 
 	// Send registry data with more than 8 key-value pairs to trigger the break.
 	// Registry body uses comma-separated key=value pairs.
-	var parts []string
+	parts := make([]string, 0, 15)
 	for i := range 15 {
 		parts = append(parts, fmt.Sprintf("Key%d=Value%d", i, i))
 	}

--- a/examples/commands/main.go
+++ b/examples/commands/main.go
@@ -365,6 +365,7 @@ func handleListDevices(server *zkadms.ADMSServer) http.Handler {
 				LastActivity: d.LastActivity.Format(time.RFC3339),
 				Online:       server.IsDeviceOnline(d.SerialNumber),
 				Options:      d.Options,
+				PendingCmds:  server.PendingCommandsCount(d.SerialNumber),
 			}
 		}
 		writeJSON(w, http.StatusOK, resp)
@@ -384,6 +385,7 @@ func handleDeviceDetail(server *zkadms.ADMSServer) http.Handler {
 			LastActivity: d.LastActivity.Format(time.RFC3339),
 			Online:       server.IsDeviceOnline(sn),
 			Options:      d.Options,
+			PendingCmds:  server.PendingCommandsCount(sn),
 		}
 		writeJSON(w, http.StatusOK, entry)
 	})

--- a/examples/commands/main.go
+++ b/examples/commands/main.go
@@ -1,0 +1,522 @@
+// Command commands demonstrates a ZKTeco ADMS server with a REST API
+// for sending management commands to devices (reboot, sync time, user
+// management, door control, etc.).
+//
+// Run with:
+//
+//	go run ./examples/commands -devices ABCD12345678,EFGH87654321
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"flag"
+	"fmt"
+	"log"
+	"log/slog"
+	"net/http"
+	"os/signal"
+	"strings"
+	"syscall"
+	"time"
+
+	zkadms "github.com/s0x90/zkteco-adms"
+)
+
+// statusRecorder wraps http.ResponseWriter to capture the status code.
+type statusRecorder struct {
+	http.ResponseWriter
+	status int
+}
+
+func (r *statusRecorder) WriteHeader(code int) {
+	r.status = code
+	r.ResponseWriter.WriteHeader(code)
+}
+
+// logMiddleware logs each HTTP request with method, path, query parameters,
+// remote address, response status code, and duration.
+func logMiddleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		rec := &statusRecorder{ResponseWriter: w, status: http.StatusOK}
+		start := time.Now()
+		defer func() {
+			slog.Info("http request",
+				"method", r.Method,
+				"path", r.URL.Path,
+				"query", r.URL.RawQuery,
+				"remote", r.RemoteAddr,
+				"status", rec.status,
+				"duration", time.Since(start),
+			)
+		}()
+		next.ServeHTTP(rec, r)
+	})
+}
+
+// ---------- JSON request/response types ----------
+
+// apiError is the JSON structure for error responses.
+type apiError struct {
+	Error string `json:"error"`
+}
+
+// commandResponse is the JSON structure for successful command responses.
+type commandResponse struct {
+	Status  string `json:"status"`
+	Device  string `json:"device"`
+	Command string `json:"command"`
+}
+
+// deviceEntry is the JSON structure for a device in list/detail responses.
+type deviceEntry struct {
+	SerialNumber string            `json:"serial_number"`
+	LastActivity string            `json:"last_activity"`
+	Online       bool              `json:"online"`
+	Options      map[string]string `json:"options,omitzero"`
+	PendingCmds  int               `json:"pending_commands"`
+}
+
+// devicesResponse is the JSON structure for the device list endpoint.
+type devicesResponse struct {
+	Count   int           `json:"count"`
+	Devices []deviceEntry `json:"devices"`
+}
+
+// userRequest is the JSON body for the add/update user endpoint.
+type userRequest struct {
+	PIN       string `json:"pin"`
+	Name      string `json:"name"`
+	Privilege int    `json:"privilege"`
+	Card      string `json:"card"`
+}
+
+// deleteUserRequest is the JSON body for the delete user endpoint.
+type deleteUserRequest struct {
+	PIN string `json:"pin"`
+}
+
+// rawCommandRequest is the JSON body for the raw command endpoint.
+type rawCommandRequest struct {
+	Command string `json:"command"`
+}
+
+// ---------- JSON helpers ----------
+
+// writeJSON encodes v as JSON and writes it to w with the given status code.
+func writeJSON(w http.ResponseWriter, status int, v any) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	if err := json.NewEncoder(w).Encode(v); err != nil {
+		slog.Warn("failed to write JSON response", "error", err)
+	}
+}
+
+// writeError writes a JSON error response.
+func writeError(w http.ResponseWriter, status int, msg string) {
+	writeJSON(w, status, apiError{Error: msg})
+}
+
+// writeCommandOK writes a JSON success response for a queued command.
+func writeCommandOK(w http.ResponseWriter, sn, cmd string) {
+	writeJSON(w, http.StatusOK, commandResponse{
+		Status:  "queued",
+		Device:  sn,
+		Command: cmd,
+	})
+}
+
+// decodeJSON reads and decodes a JSON request body into dst.
+// On failure it writes a 400 error response and returns false.
+func decodeJSON(w http.ResponseWriter, r *http.Request, dst any) bool {
+	if err := json.NewDecoder(r.Body).Decode(dst); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid JSON body: "+err.Error())
+		return false
+	}
+	return true
+}
+
+// ---------- device lookup helper ----------
+
+// requireDevice validates the serial number from the path and checks that
+// the device is registered. On failure it writes a JSON error and returns
+// ("", false).
+func requireDevice(w http.ResponseWriter, r *http.Request, server *zkadms.ADMSServer) (string, bool) {
+	sn := r.PathValue("sn")
+	if sn == "" {
+		writeError(w, http.StatusBadRequest, "missing device serial number")
+		return "", false
+	}
+	if server.GetDevice(sn) == nil {
+		writeError(w, http.StatusNotFound, fmt.Sprintf("device %s not found", sn))
+		return "", false
+	}
+	return sn, true
+}
+
+// queueOrFail queues a command and writes a JSON error on failure.
+func queueOrFail(w http.ResponseWriter, server *zkadms.ADMSServer, sn, cmd string) bool {
+	if err := server.QueueCommand(sn, cmd); err != nil {
+		if errors.Is(err, zkadms.ErrCommandQueueFull) {
+			writeError(w, http.StatusServiceUnavailable, "command queue full for device "+sn)
+		} else {
+			writeError(w, http.StatusInternalServerError, err.Error())
+		}
+		return false
+	}
+	return true
+}
+
+// ---------- command handlers ----------
+
+// handleReboot queues a REBOOT command for the device.
+func handleReboot(server *zkadms.ADMSServer) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		sn, ok := requireDevice(w, r, server)
+		if !ok {
+			return
+		}
+		if !queueOrFail(w, server, sn, "REBOOT") {
+			return
+		}
+		writeCommandOK(w, sn, "REBOOT")
+	})
+}
+
+// handleInfo queues an INFO command to request device configuration.
+func handleInfo(server *zkadms.ADMSServer) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		sn, ok := requireDevice(w, r, server)
+		if !ok {
+			return
+		}
+		if err := server.SendInfoCommand(sn); err != nil {
+			if errors.Is(err, zkadms.ErrCommandQueueFull) {
+				writeError(w, http.StatusServiceUnavailable, "command queue full for device "+sn)
+			} else {
+				writeError(w, http.StatusInternalServerError, err.Error())
+			}
+			return
+		}
+		writeCommandOK(w, sn, "INFO")
+	})
+}
+
+// handleSyncTime queues a command to synchronize the device clock to the
+// server's current time.
+func handleSyncTime(server *zkadms.ADMSServer) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		sn, ok := requireDevice(w, r, server)
+		if !ok {
+			return
+		}
+		now := time.Now().Format("2006-01-02 15:04:05")
+		cmd := "SET OPTION ServerLocalTime=" + now
+		if !queueOrFail(w, server, sn, cmd) {
+			return
+		}
+		writeCommandOK(w, sn, cmd)
+	})
+}
+
+// handleClearData queues a CLEAR DATA command to wipe attendance logs.
+func handleClearData(server *zkadms.ADMSServer) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		sn, ok := requireDevice(w, r, server)
+		if !ok {
+			return
+		}
+		if !queueOrFail(w, server, sn, "CLEAR DATA") {
+			return
+		}
+		writeCommandOK(w, sn, "CLEAR DATA")
+	})
+}
+
+// handleClearLog queues a CLEAR LOG command to wipe operation logs.
+func handleClearLog(server *zkadms.ADMSServer) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		sn, ok := requireDevice(w, r, server)
+		if !ok {
+			return
+		}
+		if !queueOrFail(w, server, sn, "CLEAR LOG") {
+			return
+		}
+		writeCommandOK(w, sn, "CLEAR LOG")
+	})
+}
+
+// handleAddUser queues a DATA UPDATE USERINFO command to add or update
+// a user on the device. Expects a JSON body with pin, name, privilege,
+// and card fields.
+func handleAddUser(server *zkadms.ADMSServer) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		sn, ok := requireDevice(w, r, server)
+		if !ok {
+			return
+		}
+		var req userRequest
+		if !decodeJSON(w, r, &req) {
+			return
+		}
+		if req.PIN == "" {
+			writeError(w, http.StatusBadRequest, "pin is required")
+			return
+		}
+		data := fmt.Sprintf("PIN=%s\tName=%s\tPri=%d\tCard=%s",
+			req.PIN, req.Name, req.Privilege, req.Card)
+		if err := server.SendDataCommand(sn, "USERINFO", data); err != nil {
+			if errors.Is(err, zkadms.ErrCommandQueueFull) {
+				writeError(w, http.StatusServiceUnavailable, "command queue full for device "+sn)
+			} else {
+				writeError(w, http.StatusInternalServerError, err.Error())
+			}
+			return
+		}
+		writeCommandOK(w, sn, "DATA UPDATE USERINFO")
+	})
+}
+
+// handleDeleteUser queues a DATA DEL_USER command to remove a user from
+// the device. Expects a JSON body with a pin field.
+func handleDeleteUser(server *zkadms.ADMSServer) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		sn, ok := requireDevice(w, r, server)
+		if !ok {
+			return
+		}
+		var req deleteUserRequest
+		if !decodeJSON(w, r, &req) {
+			return
+		}
+		if req.PIN == "" {
+			writeError(w, http.StatusBadRequest, "pin is required")
+			return
+		}
+		cmd := fmt.Sprintf("DATA DEL_USER PIN=%s", req.PIN)
+		if !queueOrFail(w, server, sn, cmd) {
+			return
+		}
+		writeCommandOK(w, sn, cmd)
+	})
+}
+
+// handleOpenDoor queues a CONTROL DEVICE command to trigger the door relay.
+func handleOpenDoor(server *zkadms.ADMSServer) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		sn, ok := requireDevice(w, r, server)
+		if !ok {
+			return
+		}
+		if !queueOrFail(w, server, sn, "CONTROL DEVICE 1 1") {
+			return
+		}
+		writeCommandOK(w, sn, "CONTROL DEVICE 1 1")
+	})
+}
+
+// handleRawCommand queues a caller-supplied command string. This is an
+// escape hatch for commands not covered by the dedicated endpoints.
+// Expects a JSON body with a command field.
+func handleRawCommand(server *zkadms.ADMSServer) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		sn, ok := requireDevice(w, r, server)
+		if !ok {
+			return
+		}
+		var req rawCommandRequest
+		if !decodeJSON(w, r, &req) {
+			return
+		}
+		if req.Command == "" {
+			writeError(w, http.StatusBadRequest, "command is required")
+			return
+		}
+		if !queueOrFail(w, server, sn, req.Command) {
+			return
+		}
+		writeCommandOK(w, sn, req.Command)
+	})
+}
+
+// ---------- query handlers ----------
+
+// handleListDevices returns all registered devices with their online status.
+func handleListDevices(server *zkadms.ADMSServer) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		devices := server.ListDevices()
+		resp := devicesResponse{
+			Count:   len(devices),
+			Devices: make([]deviceEntry, len(devices)),
+		}
+		for i, d := range devices {
+			resp.Devices[i] = deviceEntry{
+				SerialNumber: d.SerialNumber,
+				LastActivity: d.LastActivity.Format(time.RFC3339),
+				Online:       server.IsDeviceOnline(d.SerialNumber),
+				Options:      d.Options,
+			}
+		}
+		writeJSON(w, http.StatusOK, resp)
+	})
+}
+
+// handleDeviceDetail returns details for a single device.
+func handleDeviceDetail(server *zkadms.ADMSServer) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		sn, ok := requireDevice(w, r, server)
+		if !ok {
+			return
+		}
+		d := server.GetDevice(sn)
+		entry := deviceEntry{
+			SerialNumber: d.SerialNumber,
+			LastActivity: d.LastActivity.Format(time.RFC3339),
+			Online:       server.IsDeviceOnline(sn),
+			Options:      d.Options,
+		}
+		writeJSON(w, http.StatusOK, entry)
+	})
+}
+
+// ---------- wiring ----------
+
+// newMux builds the HTTP mux with all routes wired up to the given ADMS server.
+func newMux(server *zkadms.ADMSServer) *http.ServeMux {
+	mux := http.NewServeMux()
+
+	// ADMS protocol endpoints (handled by the library).
+	mux.Handle("/iclock/", logMiddleware(server))
+
+	// Device listing / detail.
+	mux.Handle("GET /api/devices", logMiddleware(handleListDevices(server)))
+	mux.Handle("GET /api/devices/{sn}", logMiddleware(handleDeviceDetail(server)))
+
+	// Command endpoints.
+	mux.Handle("POST /api/devices/{sn}/reboot", logMiddleware(handleReboot(server)))
+	mux.Handle("POST /api/devices/{sn}/info", logMiddleware(handleInfo(server)))
+	mux.Handle("POST /api/devices/{sn}/sync-time", logMiddleware(handleSyncTime(server)))
+	mux.Handle("POST /api/devices/{sn}/clear-data", logMiddleware(handleClearData(server)))
+	mux.Handle("POST /api/devices/{sn}/clear-log", logMiddleware(handleClearLog(server)))
+	mux.Handle("POST /api/devices/{sn}/users", logMiddleware(handleAddUser(server)))
+	mux.Handle("POST /api/devices/{sn}/users/delete", logMiddleware(handleDeleteUser(server)))
+	mux.Handle("POST /api/devices/{sn}/open-door", logMiddleware(handleOpenDoor(server)))
+	mux.Handle("POST /api/devices/{sn}/command", logMiddleware(handleRawCommand(server)))
+
+	return mux
+}
+
+// run creates the ADMS server, wires HTTP routes, and blocks until ctx is
+// canceled. On cancellation the HTTP server is gracefully shut down and
+// the ADMS callback queue is drained before returning.
+func run(ctx context.Context, addr string, devices []string) error {
+	server := zkadms.NewADMSServer(
+		// Enable the /iclock/inspect debug endpoint.
+		zkadms.WithEnableInspect(),
+
+		// Limit queued commands per device to prevent unbounded growth.
+		zkadms.WithMaxCommandsPerDevice(50),
+
+		// Log device info responses (sent after INFO commands).
+		zkadms.WithOnDeviceInfo(func(_ context.Context, sn string, info map[string]string) {
+			fmt.Printf("Device %s info response:\n", sn)
+			for key, value := range info {
+				fmt.Printf("  %s: %s\n", key, value)
+			}
+			fmt.Println("---")
+		}),
+
+		// Log attendance records.
+		zkadms.WithOnAttendance(func(_ context.Context, record zkadms.AttendanceRecord) {
+			fmt.Printf("Attendance: User %s at %s (status=%d, verify=%s) from %s\n",
+				record.UserID,
+				record.Timestamp.Format(time.RFC3339),
+				record.Status,
+				zkadms.VerifyModeName(record.VerifyMode),
+				record.SerialNumber)
+		}),
+	)
+	defer server.Close()
+
+	// Pre-register known devices so the API can send commands to them
+	// before they first connect. Pass device serial numbers via -devices.
+	for _, sn := range devices {
+		sn = strings.TrimSpace(sn)
+		if sn == "" {
+			continue
+		}
+		if err := server.RegisterDevice(sn); err != nil {
+			return fmt.Errorf("register device %s: %w", sn, err)
+		}
+	}
+
+	mux := newMux(server)
+
+	srv := &http.Server{Addr: addr, Handler: mux}
+
+	// Shutdown goroutine: wait for context cancellation, then gracefully
+	// stop the HTTP server so in-flight requests can finish.
+	go func() {
+		<-ctx.Done()
+		shutdownCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cancel()
+		if err := srv.Shutdown(shutdownCtx); err != nil {
+			log.Printf("HTTP server shutdown error: %v", err)
+		}
+	}()
+
+	fmt.Printf("ZKTeco Device Command Server starting on %s\n", addr)
+	fmt.Println("Endpoints:")
+	fmt.Println("  /iclock/                          - ZKTeco device ADMS endpoints")
+	fmt.Println("  /iclock/inspect                   - JSON device snapshot (debug)")
+	fmt.Println()
+	fmt.Println("  GET  /api/devices                 - List all devices")
+	fmt.Println("  GET  /api/devices/{sn}            - Device detail")
+	fmt.Println()
+	fmt.Println("  POST /api/devices/{sn}/reboot     - Reboot device")
+	fmt.Println("  POST /api/devices/{sn}/info       - Request device info")
+	fmt.Println("  POST /api/devices/{sn}/sync-time  - Sync device clock")
+	fmt.Println("  POST /api/devices/{sn}/clear-data - Clear attendance data")
+	fmt.Println("  POST /api/devices/{sn}/clear-log  - Clear operation log")
+	fmt.Println("  POST /api/devices/{sn}/users      - Add/update user (JSON body)")
+	fmt.Println("  POST /api/devices/{sn}/users/delete - Delete user (JSON body)")
+	fmt.Println("  POST /api/devices/{sn}/open-door  - Trigger door relay")
+	fmt.Println("  POST /api/devices/{sn}/command    - Send raw command (JSON body)")
+	fmt.Println()
+	fmt.Println("Example usage with curl:")
+	fmt.Println(`  curl -X POST http://localhost:8081/api/devices/<SN>/reboot`)
+	fmt.Println(`  curl -X POST http://localhost:8081/api/devices/<SN>/info`)
+	fmt.Println(`  curl -X POST http://localhost:8081/api/devices/<SN>/users \`)
+	fmt.Println(`       -H 'Content-Type: application/json' \`)
+	fmt.Println(`       -d '{"pin":"1001","name":"John Doe","privilege":0,"card":"12345678"}'`)
+	fmt.Println(`  curl -X POST http://localhost:8081/api/devices/<SN>/command \`)
+	fmt.Println(`       -H 'Content-Type: application/json' \`)
+	fmt.Println(`       -d '{"command":"ENROLL_FP PIN=1001"}'`)
+	fmt.Println()
+
+	if err := srv.ListenAndServe(); err != http.ErrServerClosed {
+		return err
+	}
+
+	log.Println("server stopped")
+	return nil
+}
+
+func main() {
+	addr := flag.String("addr", ":8081", "HTTP listen address")
+	devicesFlag := flag.String("devices", "", "comma-separated device serial numbers to pre-register")
+	flag.Parse()
+
+	var devices []string
+	if *devicesFlag != "" {
+		devices = strings.Split(*devicesFlag, ",")
+	}
+
+	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	defer stop()
+	if err := run(ctx, *addr, devices); err != nil {
+		log.Fatal(err)
+	}
+}

--- a/examples/commands/main.go
+++ b/examples/commands/main.go
@@ -2,6 +2,14 @@
 // for sending management commands to devices (reboot, sync time, user
 // management, door control, etc.).
 //
+// SECURITY WARNING: This example does NOT include any authentication or
+// authorization. All API endpoints — including reboot, clear-data, open-door,
+// and user management — are publicly accessible. In a production deployment
+// you MUST add authentication middleware (e.g. API keys, OAuth2, mTLS)
+// before exposing these routes to a network. Unauthenticated access to these
+// endpoints can lead to data loss, unauthorized physical access, and device
+// compromise.
+//
 // Run with:
 //
 //	go run ./examples/commands -devices ABCD12345678,EFGH87654321
@@ -394,7 +402,9 @@ func newMux(server *zkadms.ADMSServer) *http.ServeMux {
 	mux.Handle("GET /api/devices", logMiddleware(handleListDevices(server)))
 	mux.Handle("GET /api/devices/{sn}", logMiddleware(handleDeviceDetail(server)))
 
-	// Command endpoints.
+	// WARNING: All command endpoints below have NO authentication.
+	// In production, wrap these with auth middleware to prevent unauthorized
+	// reboot, data wipe, door unlock, and user management operations.
 	mux.Handle("POST /api/devices/{sn}/reboot", logMiddleware(handleReboot(server)))
 	mux.Handle("POST /api/devices/{sn}/info", logMiddleware(handleInfo(server)))
 	mux.Handle("POST /api/devices/{sn}/sync-time", logMiddleware(handleSyncTime(server)))

--- a/examples/commands/main_test.go
+++ b/examples/commands/main_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"log/slog"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -762,5 +763,361 @@ func TestMultipleCommandsQueued(t *testing.T) {
 	cmds := server.DrainCommands("DEV001")
 	if len(cmds) != 4 {
 		t.Errorf("expected 4 queued commands, got %d: %v", len(cmds), cmds)
+	}
+}
+
+// ---------- device not found tests for all command handlers ----------
+
+func TestSyncTime_DeviceNotFound(t *testing.T) {
+	mux := newTestMux(t)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/devices/NOSUCH/sync-time", nil)
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("expected 404, got %d", w.Code)
+	}
+	var resp apiError
+	decodeResponse(t, w, &resp)
+	if !strings.Contains(resp.Error, "NOSUCH") {
+		t.Errorf("expected error mentioning NOSUCH; got: %s", resp.Error)
+	}
+}
+
+func TestClearData_DeviceNotFound(t *testing.T) {
+	mux := newTestMux(t)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/devices/NOSUCH/clear-data", nil)
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("expected 404, got %d", w.Code)
+	}
+}
+
+func TestClearLog_DeviceNotFound(t *testing.T) {
+	mux := newTestMux(t)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/devices/NOSUCH/clear-log", nil)
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("expected 404, got %d", w.Code)
+	}
+}
+
+func TestDeleteUser_DeviceNotFound(t *testing.T) {
+	mux := newTestMux(t)
+
+	body := deleteUserRequest{PIN: "1001"}
+	req := postJSON(t, "/api/devices/NOSUCH/users/delete", body)
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("expected 404, got %d", w.Code)
+	}
+}
+
+func TestDeleteUser_InvalidJSON(t *testing.T) {
+	mux := newTestMux(t, "DEV001")
+
+	req := httptest.NewRequest(http.MethodPost, "/api/devices/DEV001/users/delete",
+		strings.NewReader("not json"))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400 for invalid JSON, got %d", w.Code)
+	}
+}
+
+func TestOpenDoor_DeviceNotFound(t *testing.T) {
+	mux := newTestMux(t)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/devices/NOSUCH/open-door", nil)
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("expected 404, got %d", w.Code)
+	}
+}
+
+func TestRawCommand_DeviceNotFound(t *testing.T) {
+	mux := newTestMux(t)
+
+	body := rawCommandRequest{Command: "REBOOT"}
+	req := postJSON(t, "/api/devices/NOSUCH/command", body)
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("expected 404, got %d", w.Code)
+	}
+}
+
+func TestInfo_DeviceNotFound(t *testing.T) {
+	mux := newTestMux(t)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/devices/NOSUCH/info", nil)
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("expected 404, got %d", w.Code)
+	}
+}
+
+// ---------- queue full tests for remaining handlers ----------
+
+func TestSyncTime_QueueFull(t *testing.T) {
+	server := zkadms.NewADMSServer(zkadms.WithMaxCommandsPerDevice(1))
+	t.Cleanup(func() { server.Close() })
+	if err := server.RegisterDevice("DEV001"); err != nil {
+		t.Fatal(err)
+	}
+
+	mux := newMux(server)
+
+	// Fill the queue.
+	req := httptest.NewRequest(http.MethodPost, "/api/devices/DEV001/sync-time", nil)
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("first command should succeed, got %d", w.Code)
+	}
+
+	// Second should fail.
+	req = httptest.NewRequest(http.MethodPost, "/api/devices/DEV001/sync-time", nil)
+	w = httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+	if w.Code != http.StatusServiceUnavailable {
+		t.Errorf("expected 503 when queue full, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestClearData_QueueFull(t *testing.T) {
+	server := zkadms.NewADMSServer(zkadms.WithMaxCommandsPerDevice(1))
+	t.Cleanup(func() { server.Close() })
+	if err := server.RegisterDevice("DEV001"); err != nil {
+		t.Fatal(err)
+	}
+
+	mux := newMux(server)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/devices/DEV001/clear-data", nil)
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("first should succeed, got %d", w.Code)
+	}
+
+	req = httptest.NewRequest(http.MethodPost, "/api/devices/DEV001/clear-data", nil)
+	w = httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+	if w.Code != http.StatusServiceUnavailable {
+		t.Errorf("expected 503, got %d", w.Code)
+	}
+}
+
+func TestClearLog_QueueFull(t *testing.T) {
+	server := zkadms.NewADMSServer(zkadms.WithMaxCommandsPerDevice(1))
+	t.Cleanup(func() { server.Close() })
+	if err := server.RegisterDevice("DEV001"); err != nil {
+		t.Fatal(err)
+	}
+
+	mux := newMux(server)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/devices/DEV001/clear-log", nil)
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("first should succeed, got %d", w.Code)
+	}
+
+	req = httptest.NewRequest(http.MethodPost, "/api/devices/DEV001/clear-log", nil)
+	w = httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+	if w.Code != http.StatusServiceUnavailable {
+		t.Errorf("expected 503, got %d", w.Code)
+	}
+}
+
+func TestDeleteUser_QueueFull(t *testing.T) {
+	server := zkadms.NewADMSServer(zkadms.WithMaxCommandsPerDevice(1))
+	t.Cleanup(func() { server.Close() })
+	if err := server.RegisterDevice("DEV001"); err != nil {
+		t.Fatal(err)
+	}
+
+	mux := newMux(server)
+
+	body := deleteUserRequest{PIN: "1001"}
+	req := postJSON(t, "/api/devices/DEV001/users/delete", body)
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("first should succeed, got %d", w.Code)
+	}
+
+	body = deleteUserRequest{PIN: "1002"}
+	req = postJSON(t, "/api/devices/DEV001/users/delete", body)
+	w = httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+	if w.Code != http.StatusServiceUnavailable {
+		t.Errorf("expected 503, got %d", w.Code)
+	}
+}
+
+func TestOpenDoor_QueueFull(t *testing.T) {
+	server := zkadms.NewADMSServer(zkadms.WithMaxCommandsPerDevice(1))
+	t.Cleanup(func() { server.Close() })
+	if err := server.RegisterDevice("DEV001"); err != nil {
+		t.Fatal(err)
+	}
+
+	mux := newMux(server)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/devices/DEV001/open-door", nil)
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("first should succeed, got %d", w.Code)
+	}
+
+	req = httptest.NewRequest(http.MethodPost, "/api/devices/DEV001/open-door", nil)
+	w = httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+	if w.Code != http.StatusServiceUnavailable {
+		t.Errorf("expected 503, got %d", w.Code)
+	}
+}
+
+func TestRawCommand_QueueFull(t *testing.T) {
+	server := zkadms.NewADMSServer(zkadms.WithMaxCommandsPerDevice(1))
+	t.Cleanup(func() { server.Close() })
+	if err := server.RegisterDevice("DEV001"); err != nil {
+		t.Fatal(err)
+	}
+
+	mux := newMux(server)
+
+	body := rawCommandRequest{Command: "CMD1"}
+	req := postJSON(t, "/api/devices/DEV001/command", body)
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("first should succeed, got %d", w.Code)
+	}
+
+	body = rawCommandRequest{Command: "CMD2"}
+	req = postJSON(t, "/api/devices/DEV001/command", body)
+	w = httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+	if w.Code != http.StatusServiceUnavailable {
+		t.Errorf("expected 503, got %d", w.Code)
+	}
+}
+
+// ---------- run() lifecycle tests with devices ----------
+
+func TestRun_WithDevices(t *testing.T) {
+	ctx, cancel := context.WithCancel(t.Context())
+
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- run(ctx, ":0", []string{"DEV001", "DEV002"})
+	}()
+
+	time.Sleep(50 * time.Millisecond)
+	cancel()
+
+	select {
+	case err := <-errCh:
+		if err != nil {
+			t.Fatalf("run returned unexpected error: %v", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("run did not return within 5s after context cancellation")
+	}
+}
+
+func TestRun_WithEmptyDeviceStrings(t *testing.T) {
+	ctx, cancel := context.WithCancel(t.Context())
+
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- run(ctx, ":0", []string{"DEV001", "", "  ", "DEV002"})
+	}()
+
+	time.Sleep(50 * time.Millisecond)
+	cancel()
+
+	select {
+	case err := <-errCh:
+		if err != nil {
+			t.Fatalf("run returned unexpected error: %v", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("run did not return within 5s")
+	}
+}
+
+// TestRun_ExercisesCallbacks starts the server via run() and sends simulated
+// ADMS device traffic to exercise the device-info and attendance callbacks.
+func TestRun_ExercisesCallbacks(t *testing.T) {
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("failed to create listener: %v", err)
+	}
+	addr := ln.Addr().String()
+	ln.Close()
+
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- run(ctx, addr, []string{"DEV001"})
+	}()
+
+	time.Sleep(100 * time.Millisecond)
+
+	base := "http://" + addr
+
+	// Send attendance data — triggers WithOnAttendance callback.
+	attendanceData := "USER001\t2026-03-20 09:00:00\t0\t1\t0\tWC1"
+	resp, err := http.Post(base+"/iclock/cdata?SN=DEV001&table=ATTLOG",
+		"text/plain", strings.NewReader(attendanceData))
+	if err != nil {
+		t.Fatalf("POST attendance failed: %v", err)
+	}
+	resp.Body.Close()
+
+	// Send device info — triggers WithOnDeviceInfo callback.
+	infoData := "FWVersion=Ver 6.60\nDeviceName=ZK-F22"
+	resp, err = http.Post(base+"/iclock/cdata?SN=DEV001",
+		"text/plain", strings.NewReader(infoData))
+	if err != nil {
+		t.Fatalf("POST device info failed: %v", err)
+	}
+	resp.Body.Close()
+
+	time.Sleep(100 * time.Millisecond)
+	cancel()
+
+	select {
+	case err := <-errCh:
+		if err != nil {
+			t.Fatalf("run returned unexpected error: %v", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("run did not return within 5s")
 	}
 }

--- a/examples/commands/main_test.go
+++ b/examples/commands/main_test.go
@@ -1087,9 +1087,23 @@ func TestRun_ExercisesCallbacks(t *testing.T) {
 		errCh <- run(ctx, addr, []string{"DEV001"})
 	}()
 
-	time.Sleep(100 * time.Millisecond)
-
+	// Wait for server to start using a readiness loop instead of a fixed sleep.
 	base := "http://" + addr
+	{
+		client := http.Client{Timeout: 500 * time.Millisecond}
+		deadline := time.Now().Add(5 * time.Second)
+		for {
+			if time.Now().After(deadline) {
+				t.Fatalf("server did not become ready within timeout")
+			}
+			resp, err := client.Get(base + "/api/devices")
+			if err == nil {
+				resp.Body.Close()
+				break
+			}
+			time.Sleep(50 * time.Millisecond)
+		}
+	}
 
 	// Send attendance data — triggers WithOnAttendance callback.
 	attendanceData := "USER001\t2026-03-20 09:00:00\t0\t1\t0\tWC1"

--- a/examples/commands/main_test.go
+++ b/examples/commands/main_test.go
@@ -1,0 +1,766 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	zkadms "github.com/s0x90/zkteco-adms"
+)
+
+// ---------- statusRecorder tests ----------
+
+func TestStatusRecorder_DefaultStatus(t *testing.T) {
+	w := httptest.NewRecorder()
+	rec := &statusRecorder{ResponseWriter: w, status: http.StatusOK}
+
+	rec.Write([]byte("hello"))
+
+	if rec.status != http.StatusOK {
+		t.Errorf("expected default status %d, got %d", http.StatusOK, rec.status)
+	}
+}
+
+func TestStatusRecorder_CapturesWriteHeader(t *testing.T) {
+	w := httptest.NewRecorder()
+	rec := &statusRecorder{ResponseWriter: w, status: http.StatusOK}
+
+	rec.WriteHeader(http.StatusNotFound)
+
+	if rec.status != http.StatusNotFound {
+		t.Errorf("expected status %d, got %d", http.StatusNotFound, rec.status)
+	}
+	if w.Code != http.StatusNotFound {
+		t.Errorf("underlying ResponseWriter should also receive %d, got %d",
+			http.StatusNotFound, w.Code)
+	}
+}
+
+// ---------- logMiddleware tests ----------
+
+func TestLogMiddleware_LogsRequest(t *testing.T) {
+	var buf bytes.Buffer
+	prev := slog.Default()
+	slog.SetDefault(slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelInfo})))
+	t.Cleanup(func() { slog.SetDefault(prev) })
+
+	inner := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusCreated)
+	})
+
+	handler := logMiddleware(inner)
+	req := httptest.NewRequest(http.MethodPost, "/test-path", nil)
+	w := httptest.NewRecorder()
+
+	handler.ServeHTTP(w, req)
+
+	logOutput := buf.String()
+	for _, want := range []string{"http request", "method=POST", "path=/test-path", "status=201", "duration="} {
+		if !strings.Contains(logOutput, want) {
+			t.Errorf("log output missing %q; got: %s", want, logOutput)
+		}
+	}
+}
+
+func TestLogMiddleware_PreservesResponseBody(t *testing.T) {
+	inner := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(`{"ok":true}`))
+	})
+
+	handler := logMiddleware(inner)
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	w := httptest.NewRecorder()
+
+	handler.ServeHTTP(w, req)
+
+	if w.Body.String() != `{"ok":true}` {
+		t.Errorf("expected body %q, got %q", `{"ok":true}`, w.Body.String())
+	}
+	if w.Header().Get("Content-Type") != "application/json" {
+		t.Errorf("expected Content-Type application/json, got %q",
+			w.Header().Get("Content-Type"))
+	}
+}
+
+// ---------- helpers ----------
+
+func newTestServer(t *testing.T, devices ...string) *zkadms.ADMSServer {
+	t.Helper()
+	server := zkadms.NewADMSServer()
+	t.Cleanup(func() { server.Close() })
+	for _, sn := range devices {
+		if err := server.RegisterDevice(sn); err != nil {
+			t.Fatalf("RegisterDevice(%q) failed: %v", sn, err)
+		}
+	}
+	return server
+}
+
+func newTestMux(t *testing.T, devices ...string) *http.ServeMux {
+	t.Helper()
+	server := newTestServer(t, devices...)
+	return newMux(server)
+}
+
+// postJSON builds a POST request with a JSON body.
+func postJSON(t *testing.T, url string, body any) *http.Request {
+	t.Helper()
+	data, err := json.Marshal(body)
+	if err != nil {
+		t.Fatalf("json.Marshal: %v", err)
+	}
+	req := httptest.NewRequest(http.MethodPost, url, bytes.NewReader(data))
+	req.Header.Set("Content-Type", "application/json")
+	return req
+}
+
+// decodeResponse decodes a JSON response body into dst.
+func decodeResponse(t *testing.T, w *httptest.ResponseRecorder, dst any) {
+	t.Helper()
+	if err := json.Unmarshal(w.Body.Bytes(), dst); err != nil {
+		t.Fatalf("failed to decode response JSON: %v\nbody: %s", err, w.Body.String())
+	}
+}
+
+// ---------- list/detail endpoint tests ----------
+
+func TestListDevices_Empty(t *testing.T) {
+	mux := newTestMux(t)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/devices", nil)
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+
+	var resp devicesResponse
+	decodeResponse(t, w, &resp)
+	if resp.Count != 0 {
+		t.Errorf("expected 0 devices, got %d", resp.Count)
+	}
+	if len(resp.Devices) != 0 {
+		t.Errorf("expected empty devices list, got %d", len(resp.Devices))
+	}
+}
+
+func TestListDevices_WithDevices(t *testing.T) {
+	mux := newTestMux(t, "DEV001", "DEV002")
+
+	req := httptest.NewRequest(http.MethodGet, "/api/devices", nil)
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+
+	var resp devicesResponse
+	decodeResponse(t, w, &resp)
+	if resp.Count != 2 {
+		t.Errorf("expected 2 devices, got %d", resp.Count)
+	}
+
+	serials := make(map[string]bool)
+	for _, d := range resp.Devices {
+		serials[d.SerialNumber] = true
+	}
+	for _, sn := range []string{"DEV001", "DEV002"} {
+		if !serials[sn] {
+			t.Errorf("expected device %s in response", sn)
+		}
+	}
+}
+
+func TestListDevices_ContentType(t *testing.T) {
+	mux := newTestMux(t)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/devices", nil)
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	ct := w.Header().Get("Content-Type")
+	if ct != "application/json" {
+		t.Errorf("expected Content-Type application/json, got %q", ct)
+	}
+}
+
+func TestDeviceDetail_Found(t *testing.T) {
+	mux := newTestMux(t, "DEV001")
+
+	req := httptest.NewRequest(http.MethodGet, "/api/devices/DEV001", nil)
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+
+	var entry deviceEntry
+	decodeResponse(t, w, &entry)
+	if entry.SerialNumber != "DEV001" {
+		t.Errorf("expected serial DEV001, got %q", entry.SerialNumber)
+	}
+	if entry.LastActivity == "" {
+		t.Error("expected non-empty last_activity")
+	}
+}
+
+func TestDeviceDetail_NotFound(t *testing.T) {
+	mux := newTestMux(t)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/devices/NOSUCH", nil)
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("expected 404, got %d", w.Code)
+	}
+
+	var resp apiError
+	decodeResponse(t, w, &resp)
+	if !strings.Contains(resp.Error, "NOSUCH") {
+		t.Errorf("expected error mentioning NOSUCH; got: %s", resp.Error)
+	}
+}
+
+// ---------- reboot tests ----------
+
+func TestReboot_Success(t *testing.T) {
+	mux := newTestMux(t, "DEV001")
+
+	req := httptest.NewRequest(http.MethodPost, "/api/devices/DEV001/reboot", nil)
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var resp commandResponse
+	decodeResponse(t, w, &resp)
+	if resp.Status != "queued" {
+		t.Errorf("expected status 'queued', got %q", resp.Status)
+	}
+	if resp.Device != "DEV001" {
+		t.Errorf("expected device DEV001, got %q", resp.Device)
+	}
+	if resp.Command != "REBOOT" {
+		t.Errorf("expected command REBOOT, got %q", resp.Command)
+	}
+}
+
+func TestReboot_DeviceNotFound(t *testing.T) {
+	mux := newTestMux(t)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/devices/NOSUCH/reboot", nil)
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("expected 404, got %d", w.Code)
+	}
+}
+
+func TestReboot_MethodNotAllowed(t *testing.T) {
+	mux := newTestMux(t, "DEV001")
+
+	req := httptest.NewRequest(http.MethodGet, "/api/devices/DEV001/reboot", nil)
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusMethodNotAllowed {
+		t.Errorf("expected 405 for GET, got %d", w.Code)
+	}
+}
+
+// ---------- info tests ----------
+
+func TestInfo_Success(t *testing.T) {
+	mux := newTestMux(t, "DEV001")
+
+	req := httptest.NewRequest(http.MethodPost, "/api/devices/DEV001/info", nil)
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var resp commandResponse
+	decodeResponse(t, w, &resp)
+	if resp.Command != "INFO" {
+		t.Errorf("expected command INFO, got %q", resp.Command)
+	}
+}
+
+// ---------- sync-time tests ----------
+
+func TestSyncTime_Success(t *testing.T) {
+	mux := newTestMux(t, "DEV001")
+
+	req := httptest.NewRequest(http.MethodPost, "/api/devices/DEV001/sync-time", nil)
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var resp commandResponse
+	decodeResponse(t, w, &resp)
+	if !strings.HasPrefix(resp.Command, "SET OPTION ServerLocalTime=") {
+		t.Errorf("expected SET OPTION ServerLocalTime= prefix, got %q", resp.Command)
+	}
+}
+
+// ---------- clear-data tests ----------
+
+func TestClearData_Success(t *testing.T) {
+	mux := newTestMux(t, "DEV001")
+
+	req := httptest.NewRequest(http.MethodPost, "/api/devices/DEV001/clear-data", nil)
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var resp commandResponse
+	decodeResponse(t, w, &resp)
+	if resp.Command != "CLEAR DATA" {
+		t.Errorf("expected command CLEAR DATA, got %q", resp.Command)
+	}
+}
+
+// ---------- clear-log tests ----------
+
+func TestClearLog_Success(t *testing.T) {
+	mux := newTestMux(t, "DEV001")
+
+	req := httptest.NewRequest(http.MethodPost, "/api/devices/DEV001/clear-log", nil)
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var resp commandResponse
+	decodeResponse(t, w, &resp)
+	if resp.Command != "CLEAR LOG" {
+		t.Errorf("expected command CLEAR LOG, got %q", resp.Command)
+	}
+}
+
+// ---------- add user tests ----------
+
+func TestAddUser_Success(t *testing.T) {
+	mux := newTestMux(t, "DEV001")
+
+	body := userRequest{PIN: "1001", Name: "John Doe", Privilege: 0, Card: "12345678"}
+	req := postJSON(t, "/api/devices/DEV001/users", body)
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var resp commandResponse
+	decodeResponse(t, w, &resp)
+	if resp.Command != "DATA UPDATE USERINFO" {
+		t.Errorf("expected command DATA UPDATE USERINFO, got %q", resp.Command)
+	}
+}
+
+func TestAddUser_MissingPIN(t *testing.T) {
+	mux := newTestMux(t, "DEV001")
+
+	body := userRequest{Name: "No PIN"}
+	req := postJSON(t, "/api/devices/DEV001/users", body)
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var resp apiError
+	decodeResponse(t, w, &resp)
+	if !strings.Contains(resp.Error, "pin") {
+		t.Errorf("expected error about pin; got: %s", resp.Error)
+	}
+}
+
+func TestAddUser_InvalidJSON(t *testing.T) {
+	mux := newTestMux(t, "DEV001")
+
+	req := httptest.NewRequest(http.MethodPost, "/api/devices/DEV001/users",
+		strings.NewReader("not json"))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400 for invalid JSON, got %d", w.Code)
+	}
+}
+
+func TestAddUser_DeviceNotFound(t *testing.T) {
+	mux := newTestMux(t)
+
+	body := userRequest{PIN: "1001", Name: "John"}
+	req := postJSON(t, "/api/devices/NOSUCH/users", body)
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("expected 404, got %d", w.Code)
+	}
+}
+
+// ---------- delete user tests ----------
+
+func TestDeleteUser_Success(t *testing.T) {
+	mux := newTestMux(t, "DEV001")
+
+	body := deleteUserRequest{PIN: "1001"}
+	req := postJSON(t, "/api/devices/DEV001/users/delete", body)
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var resp commandResponse
+	decodeResponse(t, w, &resp)
+	if !strings.Contains(resp.Command, "DATA DEL_USER PIN=1001") {
+		t.Errorf("expected DEL_USER command with PIN; got: %q", resp.Command)
+	}
+}
+
+func TestDeleteUser_MissingPIN(t *testing.T) {
+	mux := newTestMux(t, "DEV001")
+
+	body := deleteUserRequest{}
+	req := postJSON(t, "/api/devices/DEV001/users/delete", body)
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d", w.Code)
+	}
+}
+
+// ---------- open-door tests ----------
+
+func TestOpenDoor_Success(t *testing.T) {
+	mux := newTestMux(t, "DEV001")
+
+	req := httptest.NewRequest(http.MethodPost, "/api/devices/DEV001/open-door", nil)
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var resp commandResponse
+	decodeResponse(t, w, &resp)
+	if resp.Command != "CONTROL DEVICE 1 1" {
+		t.Errorf("expected command CONTROL DEVICE 1 1, got %q", resp.Command)
+	}
+}
+
+// ---------- raw command tests ----------
+
+func TestRawCommand_Success(t *testing.T) {
+	mux := newTestMux(t, "DEV001")
+
+	body := rawCommandRequest{Command: "ENROLL_FP PIN=1001"}
+	req := postJSON(t, "/api/devices/DEV001/command", body)
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var resp commandResponse
+	decodeResponse(t, w, &resp)
+	if resp.Command != "ENROLL_FP PIN=1001" {
+		t.Errorf("expected command verbatim; got %q", resp.Command)
+	}
+}
+
+func TestRawCommand_EmptyCommand(t *testing.T) {
+	mux := newTestMux(t, "DEV001")
+
+	body := rawCommandRequest{}
+	req := postJSON(t, "/api/devices/DEV001/command", body)
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400 for empty command, got %d", w.Code)
+	}
+}
+
+func TestRawCommand_InvalidJSON(t *testing.T) {
+	mux := newTestMux(t, "DEV001")
+
+	req := httptest.NewRequest(http.MethodPost, "/api/devices/DEV001/command",
+		strings.NewReader("{bad"))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d", w.Code)
+	}
+}
+
+// ---------- queue full tests ----------
+
+func TestReboot_QueueFull(t *testing.T) {
+	server := zkadms.NewADMSServer(zkadms.WithMaxCommandsPerDevice(1))
+	t.Cleanup(func() { server.Close() })
+	if err := server.RegisterDevice("DEV001"); err != nil {
+		t.Fatal(err)
+	}
+
+	mux := newMux(server)
+
+	// Fill the queue with one command.
+	req := httptest.NewRequest(http.MethodPost, "/api/devices/DEV001/reboot", nil)
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("first command should succeed, got %d: %s", w.Code, w.Body.String())
+	}
+
+	// Second command should fail.
+	req = httptest.NewRequest(http.MethodPost, "/api/devices/DEV001/reboot", nil)
+	w = httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+	if w.Code != http.StatusServiceUnavailable {
+		t.Errorf("expected 503 when queue full, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var resp apiError
+	decodeResponse(t, w, &resp)
+	if !strings.Contains(resp.Error, "queue full") {
+		t.Errorf("expected queue full error; got: %s", resp.Error)
+	}
+}
+
+func TestAddUser_QueueFull(t *testing.T) {
+	server := zkadms.NewADMSServer(zkadms.WithMaxCommandsPerDevice(1))
+	t.Cleanup(func() { server.Close() })
+	if err := server.RegisterDevice("DEV001"); err != nil {
+		t.Fatal(err)
+	}
+
+	mux := newMux(server)
+
+	// Fill with first user.
+	body := userRequest{PIN: "1001", Name: "First"}
+	req := postJSON(t, "/api/devices/DEV001/users", body)
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("first command should succeed, got %d", w.Code)
+	}
+
+	// Second should fail.
+	body = userRequest{PIN: "1002", Name: "Second"}
+	req = postJSON(t, "/api/devices/DEV001/users", body)
+	w = httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+	if w.Code != http.StatusServiceUnavailable {
+		t.Errorf("expected 503, got %d", w.Code)
+	}
+}
+
+func TestInfo_QueueFull(t *testing.T) {
+	server := zkadms.NewADMSServer(zkadms.WithMaxCommandsPerDevice(1))
+	t.Cleanup(func() { server.Close() })
+	if err := server.RegisterDevice("DEV001"); err != nil {
+		t.Fatal(err)
+	}
+
+	mux := newMux(server)
+
+	// Fill the queue.
+	req := httptest.NewRequest(http.MethodPost, "/api/devices/DEV001/info", nil)
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("first should succeed, got %d", w.Code)
+	}
+
+	// Second should fail.
+	req = httptest.NewRequest(http.MethodPost, "/api/devices/DEV001/info", nil)
+	w = httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+	if w.Code != http.StatusServiceUnavailable {
+		t.Errorf("expected 503, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+// ---------- method not allowed tests ----------
+
+func TestCommandEndpoints_MethodNotAllowed(t *testing.T) {
+	mux := newTestMux(t, "DEV001")
+
+	postOnlyPaths := []string{
+		"/api/devices/DEV001/reboot",
+		"/api/devices/DEV001/info",
+		"/api/devices/DEV001/sync-time",
+		"/api/devices/DEV001/clear-data",
+		"/api/devices/DEV001/clear-log",
+		"/api/devices/DEV001/users",
+		"/api/devices/DEV001/users/delete",
+		"/api/devices/DEV001/open-door",
+		"/api/devices/DEV001/command",
+	}
+
+	for _, path := range postOnlyPaths {
+		t.Run("GET "+path, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodGet, path, nil)
+			w := httptest.NewRecorder()
+			mux.ServeHTTP(w, req)
+
+			if w.Code != http.StatusMethodNotAllowed {
+				t.Errorf("expected 405 for GET %s, got %d", path, w.Code)
+			}
+		})
+	}
+}
+
+// ---------- iclock route test ----------
+
+func TestNewMux_IClockRoute(t *testing.T) {
+	mux := newTestMux(t)
+
+	req := httptest.NewRequest(http.MethodGet, "/iclock/cdata", nil)
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	// The route should be handled by the ADMS server, not 404.
+	if w.Code == http.StatusNotFound {
+		t.Error("/iclock/cdata should be handled by ADMS server, not 404")
+	}
+}
+
+// ---------- unknown route test ----------
+
+func TestNewMux_UnknownRoute(t *testing.T) {
+	mux := newTestMux(t)
+
+	req := httptest.NewRequest(http.MethodGet, "/nonexistent", nil)
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusNotFound {
+		t.Errorf("expected 404 for unknown route, got %d", w.Code)
+	}
+}
+
+// ---------- mux logging integration test ----------
+
+func TestNewMux_LogsRequests(t *testing.T) {
+	var buf bytes.Buffer
+	prev := slog.Default()
+	slog.SetDefault(slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelInfo})))
+	t.Cleanup(func() { slog.SetDefault(prev) })
+
+	mux := newTestMux(t, "DEV001")
+
+	req := httptest.NewRequest(http.MethodGet, "/api/devices", nil)
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	logOutput := buf.String()
+	if !strings.Contains(logOutput, "http request") {
+		t.Errorf("expected log from logMiddleware; got: %s", logOutput)
+	}
+	if !strings.Contains(logOutput, "path=/api/devices") {
+		t.Errorf("expected path=/api/devices in log; got: %s", logOutput)
+	}
+}
+
+// ---------- run() lifecycle tests ----------
+
+func TestRun_StartsAndStops(t *testing.T) {
+	ctx, cancel := context.WithCancel(t.Context())
+
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- run(ctx, ":0", nil)
+	}()
+
+	// Give the server a moment to start listening.
+	time.Sleep(50 * time.Millisecond)
+	cancel()
+
+	select {
+	case err := <-errCh:
+		if err != nil {
+			t.Fatalf("run returned unexpected error: %v", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("run did not return within 5s after context cancellation")
+	}
+}
+
+func TestRun_InvalidAddr(t *testing.T) {
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+
+	err := run(ctx, ":-1", nil)
+	if err == nil {
+		t.Fatal("expected error for invalid address, got nil")
+	}
+}
+
+// ---------- multiple commands queued in sequence ----------
+
+func TestMultipleCommandsQueued(t *testing.T) {
+	server := newTestServer(t, "DEV001")
+	mux := newMux(server)
+
+	// Queue several different commands.
+	endpoints := []string{
+		"/api/devices/DEV001/reboot",
+		"/api/devices/DEV001/info",
+		"/api/devices/DEV001/clear-data",
+		"/api/devices/DEV001/open-door",
+	}
+
+	for _, ep := range endpoints {
+		req := httptest.NewRequest(http.MethodPost, ep, nil)
+		w := httptest.NewRecorder()
+		mux.ServeHTTP(w, req)
+		if w.Code != http.StatusOK {
+			t.Fatalf("POST %s: expected 200, got %d: %s", ep, w.Code, w.Body.String())
+		}
+	}
+
+	// All commands should be pending.
+	cmds := server.DrainCommands("DEV001")
+	if len(cmds) != 4 {
+		t.Errorf("expected 4 queued commands, got %d: %v", len(cmds), cmds)
+	}
+}

--- a/examples/database/main.go
+++ b/examples/database/main.go
@@ -2,6 +2,12 @@
 // attendance store and JSON query endpoints, modeled after a typical
 // database-backed integration.
 //
+// SECURITY WARNING: This example does NOT include any authentication or
+// authorization. The /api/attendance and /api/summary/today endpoints are
+// publicly accessible and expose employee attendance data. In a production
+// deployment you MUST add authentication middleware (e.g. API keys, OAuth2,
+// mTLS) before exposing these routes to a network.
+//
 // Run with:
 //
 //	go run ./examples/database
@@ -235,6 +241,8 @@ func summaryHandler(store *AttendanceStore) http.Handler {
 func newMux(server *zkadms.ADMSServer, store *AttendanceStore) *http.ServeMux {
 	mux := http.NewServeMux()
 	mux.Handle("/iclock/", logMiddleware(server))
+	// WARNING: These routes have no authentication and expose attendance
+	// data. Add auth middleware before deploying to production.
 	mux.Handle("/api/attendance", logMiddleware(attendanceHandler(store)))
 	mux.Handle("/api/summary/today", logMiddleware(summaryHandler(store)))
 	return mux

--- a/examples/database/main_test.go
+++ b/examples/database/main_test.go
@@ -680,9 +680,23 @@ func TestRun_ExercisesCallbacks(t *testing.T) {
 		errCh <- run(ctx, addr)
 	}()
 
-	time.Sleep(100 * time.Millisecond)
-
+	// Wait for server to start using a readiness loop instead of a fixed sleep.
 	base := "http://" + addr
+	{
+		client := http.Client{Timeout: 500 * time.Millisecond}
+		deadline := time.Now().Add(5 * time.Second)
+		for {
+			if time.Now().After(deadline) {
+				t.Fatalf("server did not become ready within timeout")
+			}
+			resp, err := client.Get(base + "/api/attendance")
+			if err == nil {
+				resp.Body.Close()
+				break
+			}
+			time.Sleep(50 * time.Millisecond)
+		}
+	}
 
 	// 1. Send attendance data — triggers WithOnAttendance callback which
 	//    calls store.SaveAttendance.

--- a/examples/database/main_test.go
+++ b/examples/database/main_test.go
@@ -4,7 +4,9 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"fmt"
 	"log/slog"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -656,5 +658,157 @@ func TestRun_InvalidAddr(t *testing.T) {
 	err := run(ctx, ":-1")
 	if err == nil {
 		t.Fatal("expected error for invalid address, got nil")
+	}
+}
+
+// TestRun_ExercisesCallbacks starts the server via run() and sends simulated
+// ADMS device traffic to exercise the attendance and device-info callbacks
+// wired inside run().
+func TestRun_ExercisesCallbacks(t *testing.T) {
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("failed to create listener: %v", err)
+	}
+	addr := ln.Addr().String()
+	ln.Close()
+
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- run(ctx, addr)
+	}()
+
+	time.Sleep(100 * time.Millisecond)
+
+	base := "http://" + addr
+
+	// 1. Send attendance data — triggers WithOnAttendance callback which
+	//    calls store.SaveAttendance.
+	attendanceData := "USER001\t2026-03-20 09:00:00\t0\t1\t0\tWC1"
+	resp, err := http.Post(base+"/iclock/cdata?SN=TEST001&table=ATTLOG",
+		"text/plain", strings.NewReader(attendanceData))
+	if err != nil {
+		t.Fatalf("POST attendance failed: %v", err)
+	}
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("expected 200 for attendance POST, got %d", resp.StatusCode)
+	}
+
+	// 2. Send device info — triggers WithOnDeviceInfo callback.
+	infoData := "FWVersion=Ver 6.60\nDeviceName=ZK-F22"
+	resp, err = http.Post(base+"/iclock/cdata?SN=TEST001",
+		"text/plain", strings.NewReader(infoData))
+	if err != nil {
+		t.Fatalf("POST device info failed: %v", err)
+	}
+	resp.Body.Close()
+
+	// Give callbacks time to be processed.
+	time.Sleep(200 * time.Millisecond)
+
+	// 3. Verify the attendance record was stored via the API.
+	resp, err = http.Get(base + "/api/attendance")
+	if err != nil {
+		t.Fatalf("GET /api/attendance failed: %v", err)
+	}
+	defer resp.Body.Close()
+
+	var attResp attendanceResponse
+	if err := json.NewDecoder(resp.Body).Decode(&attResp); err != nil {
+		t.Fatalf("failed to decode attendance response: %v", err)
+	}
+	if attResp.Total != 1 {
+		t.Errorf("expected 1 attendance record stored via callback, got %d", attResp.Total)
+	}
+
+	// 4. Verify today's summary shows the record.
+	resp, err = http.Get(base + "/api/summary/today")
+	if err != nil {
+		t.Fatalf("GET /api/summary/today failed: %v", err)
+	}
+	resp.Body.Close()
+
+	cancel()
+
+	select {
+	case err := <-errCh:
+		if err != nil {
+			t.Fatalf("run returned unexpected error: %v", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("run did not return within 5s after context cancellation")
+	}
+}
+
+// ---------- concurrent access test ----------
+
+func TestAttendanceStore_ConcurrentAccess(t *testing.T) {
+	store := NewAttendanceStore()
+	ts := time.Date(2026, 3, 17, 9, 0, 0, 0, time.UTC)
+
+	// Write from multiple goroutines.
+	done := make(chan struct{})
+	for i := range 10 {
+		go func(id int) {
+			defer func() { done <- struct{}{} }()
+			for j := range 10 {
+				_ = store.SaveAttendance(zkadms.AttendanceRecord{
+					UserID:       fmt.Sprintf("USER%d", id),
+					Timestamp:    ts.Add(time.Duration(j) * time.Minute),
+					SerialNumber: "DEV001",
+				})
+			}
+		}(i)
+	}
+	for range 10 {
+		<-done
+	}
+
+	records := store.GetRecords()
+	if len(records) != 100 {
+		t.Errorf("expected 100 records, got %d", len(records))
+	}
+}
+
+// ---------- attendanceHandler additional tests ----------
+
+func TestAttendanceHandler_MultipleUsers(t *testing.T) {
+	store := NewAttendanceStore()
+	ts := time.Date(2026, 3, 17, 9, 0, 0, 0, time.UTC)
+	seedStore(t, store,
+		zkadms.AttendanceRecord{UserID: "U1", Timestamp: ts, Status: 0, SerialNumber: "D1"},
+		zkadms.AttendanceRecord{UserID: "U2", Timestamp: ts, Status: 0, SerialNumber: "D1"},
+		zkadms.AttendanceRecord{UserID: "U3", Timestamp: ts, Status: 0, SerialNumber: "D2"},
+		zkadms.AttendanceRecord{UserID: "U1", Timestamp: ts.Add(8 * time.Hour), Status: 1, SerialNumber: "D1"},
+	)
+
+	handler := attendanceHandler(store)
+
+	// Filter by U1 — should get 2 records.
+	req := httptest.NewRequest(http.MethodGet, "/api/attendance?user_id=U1", nil)
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	var resp attendanceResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatal(err)
+	}
+	if resp.Count != 2 {
+		t.Errorf("expected 2 records for U1, got %d", resp.Count)
+	}
+
+	// All records — should get 4.
+	req = httptest.NewRequest(http.MethodGet, "/api/attendance", nil)
+	w = httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatal(err)
+	}
+	if resp.Total != 4 {
+		t.Errorf("expected 4 total records, got %d", resp.Total)
 	}
 }


### PR DESCRIPTION
## Summary

- **New `examples/commands` REST API example** with `-devices` CLI flag for pre-registering device serial numbers
- **Device registration limit** (default: 1000) with `WithMaxDevices(n)` / `WithUnlimitedDevices()` options
- **Background eviction worker** that removes stale devices after configurable inactivity timeout (default: 24h)
- **`PendingCommandsCount(sn)` method** to inspect command queue depth without draining
- Security warning comments added to example endpoints
- Additional integration-style tests for all example servers

## Breaking Changes

- The default maximum device limit is now **1000** (previously unlimited). Use `WithUnlimitedDevices()` to restore the previous behavior.

## Copilot Review Fixes

- Populated `pending_commands` field in device list/detail JSON responses (was always 0)
- Replaced flaky `time.Sleep` readiness waits in tests with polling loops
- Updated README to document new defaults, options, and methods