### PR TITLE
Add per-device timezone support for correct attendance timestamp parsing

### DIFF
--- a/SUGGESTIONS_NEXT.md
+++ b/SUGGESTIONS_NEXT.md
@@ -1,0 +1,68 @@
+# Suggestions for Next PR
+
+Carried over from the PR #28 code review.
+
+## MEDIUM: Add nil guard in `parseAttendanceRecords`
+
+**Location:** `adms.go:1352`
+
+`parseAttendanceRecords` passes `loc` directly to `time.ParseInLocation`, which panics on nil.
+Today all callers go through `deviceLocationLocked` which guarantees non-nil, but a future
+call site (bulk import, test helper) could pass nil and trigger a runtime panic.
+
+```go
+func (s *ADMSServer) parseAttendanceRecords(data string, serialNumber string, loc *time.Location) []AttendanceRecord {
+	if loc == nil {
+		loc = time.UTC
+	}
+	// ...
+}
+```
+
+## LOW: Document nil behavior of `WithDeviceTimezone`
+
+**Location:** `adms.go:200-207`
+
+`WithDefaultTimezone` guards against nil; `WithDeviceTimezone` does not. The asymmetry is
+confusing. At minimum, document that nil clears the device-specific timezone and falls back
+to the server default.
+
+```go
+// WithDeviceTimezone sets the timezone for a device. Attendance timestamps
+// from this device are interpreted in the given location using
+// [time.ParseInLocation]. Pass nil to clear the device-specific timezone
+// and fall back to the server default (see [WithDefaultTimezone]).
+func WithDeviceTimezone(loc *time.Location) DeviceOption {
+	return func(d *Device) {
+		d.Timezone = loc
+	}
+}
+```
+
+## LOW: Clarify `RegisterDevice` idempotency contract
+
+**Location:** `adms.go:953-975`
+
+`RegisterDevice` changed from no-op-on-existing to upsert. Document explicitly that omitted
+options retain their current values and calling without options is a no-op for existing devices.
+
+```go
+// RegisterDevice registers a new device or updates the options of an existing one.
+// When called for an existing device, only the provided [DeviceOption] values are
+// applied; omitted options retain their current values. Calling RegisterDevice
+// without options on an existing device is a no-op.
+```
+
+## LOW: Document TOCTOU behavior in `HandleCData` timezone resolution
+
+**Location:** `adms.go:1098-1103`
+
+The timezone is resolved under `RLock` and then used outside the lock. A concurrent
+`SetDeviceTimezone` call could change the timezone between resolution and parsing.
+Add a comment documenting this acceptable trade-off.
+
+```go
+// NOTE: The timezone is resolved at the start of ATTLOG processing.
+// If the device's timezone is changed concurrently, records already
+// being parsed will use the previously resolved timezone.
+```

--- a/adms.go
+++ b/adms.go
@@ -180,6 +180,10 @@ var (
 
 	// ErrInvalidSerialNumber is returned when a serial number fails validation.
 	ErrInvalidSerialNumber = errors.New("zkadms: invalid serial number")
+
+	// ErrDeviceNotFound is returned when an operation targets a device that
+	// is not registered with the server.
+	ErrDeviceNotFound = errors.New("zkadms: device not found")
 )
 
 // serialNumberRe matches valid device serial numbers: 1–64 alphanumeric
@@ -188,6 +192,20 @@ var serialNumberRe = regexp.MustCompile(`^[A-Za-z0-9_-]{1,64}$`)
 
 // Option configures an [ADMSServer]. Use the With* functions to obtain options.
 type Option func(*ADMSServer)
+
+// DeviceOption configures a [Device] during registration.
+// Use the WithDevice* functions to obtain device options.
+type DeviceOption func(*Device)
+
+// WithDeviceTimezone sets the timezone for a device. Attendance timestamps
+// from this device are interpreted in the given location using
+// [time.ParseInLocation]. If not set, the server's default timezone is used
+// (see [WithDefaultTimezone]).
+func WithDeviceTimezone(loc *time.Location) DeviceOption {
+	return func(d *Device) {
+		d.Timezone = loc
+	}
+}
 
 // WithLogger sets the structured logger for the server.
 // If not provided, [slog.Default] is used.
@@ -365,19 +383,33 @@ func WithDeviceEvictionTimeout(d time.Duration) Option {
 	}
 }
 
+// WithDefaultTimezone sets the fallback timezone used to interpret attendance
+// timestamps from devices that have no explicit timezone configured via
+// [WithDeviceTimezone]. The default is [time.UTC].
+func WithDefaultTimezone(loc *time.Location) Option {
+	return func(s *ADMSServer) {
+		if loc != nil {
+			s.defaultTimezone = loc
+		}
+	}
+}
+
 // Device represents a ZKTeco device
 type Device struct {
 	SerialNumber string
 	LastActivity time.Time
 	Options      map[string]string
+	Timezone     *time.Location // nil = use server default (see WithDefaultTimezone)
 }
 
 // copy returns a deep copy of the Device, including its Options map.
+// Timezone is a shallow copy because *time.Location is immutable after creation.
 func (d *Device) copy() *Device {
 	return &Device{
 		SerialNumber: d.SerialNumber,
 		LastActivity: d.LastActivity,
 		Options:      maps.Clone(d.Options),
+		Timezone:     d.Timezone,
 	}
 }
 
@@ -397,6 +429,7 @@ type DeviceSnapshot struct {
 	LastActivity string            `json:"lastActivity"`
 	Online       bool              `json:"online"`
 	Options      map[string]string `json:"options"`
+	Timezone     string            `json:"timezone"`
 }
 
 // CommandResult represents the result of a command execution reported by a
@@ -500,6 +533,8 @@ type ADMSServer struct {
 	deviceEvictionInterval time.Duration // how often the eviction worker runs
 	deviceEvictionTimeout  time.Duration // inactivity threshold for eviction
 
+	defaultTimezone *time.Location // fallback TZ for devices without explicit timezone
+
 	baseCtx       context.Context
 	baseCtxCancel context.CancelFunc
 
@@ -535,6 +570,7 @@ func NewADMSServer(opts ...Option) *ADMSServer {
 		dispatchTimeout:        defaultDispatchTimeout,
 		deviceEvictionInterval: defaultDeviceEvictionInterval,
 		deviceEvictionTimeout:  defaultDeviceEvictionTimeout,
+		defaultTimezone:        time.UTC,
 		callbackDone:           make(chan struct{}),
 		evictionDone:           make(chan struct{}),
 		closeCh:                make(chan struct{}),
@@ -905,11 +941,16 @@ func (s *ADMSServer) registerOrReject(w http.ResponseWriter, serialNumber string
 	return true
 }
 
-// RegisterDevice registers a new device.
+// RegisterDevice registers a new device or updates an existing one.
 // It returns [ErrMaxDevicesReached] if the server's device limit (configured
 // via [WithMaxDevices]) has been reached and the device is not already known.
 // It returns [ErrInvalidSerialNumber] if the serial number is malformed.
-func (s *ADMSServer) RegisterDevice(serialNumber string) error {
+//
+// Use [DeviceOption] values to configure the device:
+//
+//	loc, _ := time.LoadLocation("Europe/Istanbul")
+//	server.RegisterDevice("SN001", WithDeviceTimezone(loc))
+func (s *ADMSServer) RegisterDevice(serialNumber string, opts ...DeviceOption) error {
 	if err := validateSerialNumber(serialNumber); err != nil {
 		return err
 	}
@@ -917,15 +958,20 @@ func (s *ADMSServer) RegisterDevice(serialNumber string) error {
 	s.devicesMutex.Lock()
 	defer s.devicesMutex.Unlock()
 
-	if _, exists := s.devices[serialNumber]; !exists {
+	dev, exists := s.devices[serialNumber]
+	if !exists {
 		if s.maxDevices > 0 && len(s.devices) >= s.maxDevices {
 			return ErrMaxDevicesReached
 		}
-		s.devices[serialNumber] = &Device{
+		dev = &Device{
 			SerialNumber: serialNumber,
 			LastActivity: time.Now(),
 			Options:      make(map[string]string),
 		}
+		s.devices[serialNumber] = dev
+	}
+	for _, opt := range opts {
+		opt(dev)
 	}
 	return nil
 }
@@ -949,6 +995,35 @@ func (s *ADMSServer) IsDeviceOnline(serialNumber string) bool {
 	defer s.devicesMutex.RUnlock()
 	d := s.devices[serialNumber]
 	return s.isDeviceOnline(d)
+}
+
+// SetDeviceTimezone sets the timezone for a registered device. Attendance
+// timestamps from this device will be interpreted in the given location.
+// Pass nil to clear the device-specific timezone and fall back to the
+// server default (see [WithDefaultTimezone]).
+// Returns [ErrDeviceNotFound] if the device is not registered.
+func (s *ADMSServer) SetDeviceTimezone(serialNumber string, loc *time.Location) error {
+	s.devicesMutex.Lock()
+	defer s.devicesMutex.Unlock()
+	d := s.devices[serialNumber]
+	if d == nil {
+		return ErrDeviceNotFound
+	}
+	d.Timezone = loc
+	return nil
+}
+
+// GetDeviceTimezone returns the effective timezone for a device.
+// Resolution order: device-specific timezone, server default
+// ([WithDefaultTimezone]), then [time.UTC].
+// Returns nil if the device is not registered.
+func (s *ADMSServer) GetDeviceTimezone(serialNumber string) *time.Location {
+	s.devicesMutex.RLock()
+	defer s.devicesMutex.RUnlock()
+	if s.devices[serialNumber] == nil {
+		return nil
+	}
+	return s.deviceLocationLocked(serialNumber)
 }
 
 // QueueCommand adds a command to be sent to the device on its next poll.
@@ -1020,7 +1095,12 @@ func (s *ADMSServer) HandleCData(w http.ResponseWriter, r *http.Request) {
 			s.logger.Debug("ATTLOG body", "preview", bodyPreview(body))
 		}
 
-		records := s.parseAttendanceRecords(string(body), serialNumber)
+		// Resolve the device's timezone for timestamp interpretation.
+		s.devicesMutex.RLock()
+		loc := s.deviceLocationLocked(serialNumber)
+		s.devicesMutex.RUnlock()
+
+		records := s.parseAttendanceRecords(string(body), serialNumber, loc)
 		if !s.dispatchAttendance(records) {
 			s.logger.Error("callback queue full, records not processed",
 				"count", len(records), "device", serialNumber)
@@ -1246,11 +1326,30 @@ func (s *ADMSServer) isDeviceOnline(device *Device) bool {
 	return time.Since(device.LastActivity) <= s.onlineThreshold
 }
 
+// deviceLocationLocked returns the timezone to use when parsing attendance
+// timestamps for the given device. Resolution order: device-specific timezone,
+// server default (defaultTimezone), then time.UTC.
+//
+// The caller must hold devicesMutex (at least RLock).
+func (s *ADMSServer) deviceLocationLocked(serialNumber string) *time.Location {
+	if d := s.devices[serialNumber]; d != nil && d.Timezone != nil {
+		return d.Timezone
+	}
+	if s.defaultTimezone != nil {
+		return s.defaultTimezone
+	}
+	return time.UTC
+}
+
 // parseAttendanceRecords parses attendance records from the device ATTLOG data.
 // Each line must have at least a UserID and a parseable timestamp (either
 // "2006-01-02 15:04:05" format or a Unix epoch integer). Malformed lines are
 // skipped and logged so downstream systems never receive zero-value timestamps.
-func (s *ADMSServer) parseAttendanceRecords(data string, serialNumber string) []AttendanceRecord {
+//
+// The loc parameter specifies the timezone in which device-local timestamps
+// (the "2006-01-02 15:04:05" format) are interpreted. Unix epoch timestamps
+// are inherently UTC and are not affected by loc.
+func (s *ADMSServer) parseAttendanceRecords(data string, serialNumber string, loc *time.Location) []AttendanceRecord {
 	var records []AttendanceRecord
 	var skipped int
 	for line := range strings.SplitSeq(strings.TrimSpace(data), "\n") {
@@ -1274,17 +1373,8 @@ func (s *ADMSServer) parseAttendanceRecords(data string, serialNumber string) []
 			continue
 		}
 
-		// TODO(timezone): time.Parse returns timestamps without a timezone
-		// (effectively UTC), but ZKTeco devices report timestamps in their
-		// configured local time. For any deployment where devices are not set
-		// to UTC this produces silently wrong timestamps — e.g. a 09:00 local
-		// check-in is stored as 09:00 UTC instead of the correct UTC offset.
-		// This affects payroll, compliance reports, and any cross-timezone
-		// logic. A future WithDeviceTimezone(*time.Location) option should
-		// switch this call to time.ParseInLocation so the server can
-		// interpret device-local timestamps correctly.
 		var ts time.Time
-		if parsed, err := time.Parse(timestampFormat, parts[attFieldTimestamp]); err == nil {
+		if parsed, err := time.ParseInLocation(timestampFormat, parts[attFieldTimestamp], loc); err == nil {
 			ts = parsed
 		} else if epoch, err := strconv.ParseInt(parts[attFieldTimestamp], 10, 64); err == nil {
 			ts = time.Unix(epoch, 0)
@@ -1624,6 +1714,7 @@ func (s *ADMSServer) HandleInspect(w http.ResponseWriter, r *http.Request) {
 			LastActivity: dc.LastActivity.Format(time.RFC3339),
 			Online:       s.isDeviceOnline(d),
 			Options:      dc.Options,
+			Timezone:     s.deviceLocationLocked(dc.SerialNumber).String(),
 		}
 		snapshot.Devices = append(snapshot.Devices, snap)
 	}

--- a/adms_test.go
+++ b/adms_test.go
@@ -695,7 +695,7 @@ func TestParseAttendanceRecords(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			records := server.parseAttendanceRecords(tc.data, "TEST001")
+			records := server.parseAttendanceRecords(tc.data, "TEST001", time.UTC)
 			if len(records) != tc.expected {
 				t.Errorf("Expected %d records, got %d", tc.expected, len(records))
 			}
@@ -1121,7 +1121,7 @@ func BenchmarkParseAttendanceRecords(b *testing.B) {
 	data := "123\t2024-01-01 08:00:00\t0\t1\t0\n456\t2024-01-01 17:00:00\t1\t1\t0\n789\t2024-01-01 12:00:00\t2\t1\t0"
 
 	for b.Loop() {
-		server.parseAttendanceRecords(data, "TEST001")
+		server.parseAttendanceRecords(data, "TEST001", time.UTC)
 	}
 }
 
@@ -4443,5 +4443,571 @@ func TestHandleCData_USERINFO_CallbackQueueFull(t *testing.T) {
 	// (it logs a warning instead of returning 503).
 	if w3.Code != http.StatusOK {
 		t.Errorf("expected 200, got %d", w3.Code)
+	}
+}
+
+// --- Timezone Tests ---
+
+func TestRegisterDevice_WithTimezone(t *testing.T) {
+	server := NewADMSServer()
+	defer server.Close()
+
+	istanbul, err := time.LoadLocation("Europe/Istanbul")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := server.RegisterDevice("DEV001", WithDeviceTimezone(istanbul)); err != nil {
+		t.Fatalf("RegisterDevice failed: %v", err)
+	}
+
+	dev := server.GetDevice("DEV001")
+	if dev == nil {
+		t.Fatal("device should be registered")
+	}
+	if dev.Timezone == nil {
+		t.Fatal("expected device timezone to be set")
+	}
+	if dev.Timezone.String() != "Europe/Istanbul" {
+		t.Errorf("expected Europe/Istanbul, got %s", dev.Timezone.String())
+	}
+}
+
+func TestRegisterDevice_WithoutTimezone(t *testing.T) {
+	server := NewADMSServer()
+	defer server.Close()
+
+	if err := server.RegisterDevice("DEV001"); err != nil {
+		t.Fatalf("RegisterDevice failed: %v", err)
+	}
+
+	dev := server.GetDevice("DEV001")
+	if dev.Timezone != nil {
+		t.Errorf("expected nil timezone, got %s", dev.Timezone.String())
+	}
+}
+
+func TestRegisterDevice_ReRegistration_AppliesOpts(t *testing.T) {
+	server := NewADMSServer()
+	defer server.Close()
+
+	if err := server.RegisterDevice("DEV001"); err != nil {
+		t.Fatalf("RegisterDevice failed: %v", err)
+	}
+	dev := server.GetDevice("DEV001")
+	if dev.Timezone != nil {
+		t.Errorf("expected nil timezone initially, got %v", dev.Timezone)
+	}
+
+	berlin, err := time.LoadLocation("Europe/Berlin")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := server.RegisterDevice("DEV001", WithDeviceTimezone(berlin)); err != nil {
+		t.Fatalf("re-RegisterDevice failed: %v", err)
+	}
+	dev = server.GetDevice("DEV001")
+	if dev.Timezone == nil || dev.Timezone.String() != "Europe/Berlin" {
+		t.Errorf("expected Europe/Berlin after re-registration, got %v", dev.Timezone)
+	}
+}
+
+func TestSetDeviceTimezone(t *testing.T) {
+	server := NewADMSServer()
+	defer server.Close()
+
+	if err := server.RegisterDevice("DEV001"); err != nil {
+		t.Fatalf("RegisterDevice failed: %v", err)
+	}
+
+	tokyo, err := time.LoadLocation("Asia/Tokyo")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := server.SetDeviceTimezone("DEV001", tokyo); err != nil {
+		t.Fatalf("SetDeviceTimezone failed: %v", err)
+	}
+
+	dev := server.GetDevice("DEV001")
+	if dev.Timezone == nil || dev.Timezone.String() != "Asia/Tokyo" {
+		t.Errorf("expected Asia/Tokyo, got %v", dev.Timezone)
+	}
+}
+
+func TestSetDeviceTimezone_ClearWithNil(t *testing.T) {
+	server := NewADMSServer()
+	defer server.Close()
+
+	tokyo, err := time.LoadLocation("Asia/Tokyo")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := server.RegisterDevice("DEV001", WithDeviceTimezone(tokyo)); err != nil {
+		t.Fatalf("RegisterDevice failed: %v", err)
+	}
+
+	if err := server.SetDeviceTimezone("DEV001", nil); err != nil {
+		t.Fatalf("SetDeviceTimezone(nil) failed: %v", err)
+	}
+	dev := server.GetDevice("DEV001")
+	if dev.Timezone != nil {
+		t.Errorf("expected nil timezone after clearing, got %v", dev.Timezone)
+	}
+}
+
+func TestSetDeviceTimezone_UnknownDevice(t *testing.T) {
+	server := NewADMSServer()
+	defer server.Close()
+
+	err := server.SetDeviceTimezone("NOSUCH", time.UTC)
+	if !errors.Is(err, ErrDeviceNotFound) {
+		t.Errorf("expected ErrDeviceNotFound, got %v", err)
+	}
+}
+
+func TestGetDeviceTimezone_FallbackChain(t *testing.T) {
+	// Case 1: device timezone set → returns device timezone
+	istanbul, err := time.LoadLocation("Europe/Istanbul")
+	if err != nil {
+		t.Fatal(err)
+	}
+	server := NewADMSServer()
+	defer server.Close()
+
+	if err := server.RegisterDevice("DEV001", WithDeviceTimezone(istanbul)); err != nil {
+		t.Fatalf("RegisterDevice failed: %v", err)
+	}
+	loc := server.GetDeviceTimezone("DEV001")
+	if loc == nil || loc.String() != "Europe/Istanbul" {
+		t.Errorf("expected Europe/Istanbul, got %v", loc)
+	}
+
+	// Case 2: no device timezone → returns server default
+	berlin, err := time.LoadLocation("Europe/Berlin")
+	if err != nil {
+		t.Fatal(err)
+	}
+	server2 := NewADMSServer(WithDefaultTimezone(berlin))
+	defer server2.Close()
+
+	if err := server2.RegisterDevice("DEV002"); err != nil {
+		t.Fatalf("RegisterDevice failed: %v", err)
+	}
+	loc = server2.GetDeviceTimezone("DEV002")
+	if loc == nil || loc.String() != "Europe/Berlin" {
+		t.Errorf("expected Europe/Berlin (server default), got %v", loc)
+	}
+
+	// Case 3: no device timezone, no custom server default → returns UTC
+	server3 := NewADMSServer()
+	defer server3.Close()
+
+	if err := server3.RegisterDevice("DEV003"); err != nil {
+		t.Fatalf("RegisterDevice failed: %v", err)
+	}
+	loc = server3.GetDeviceTimezone("DEV003")
+	if loc == nil || loc.String() != "UTC" {
+		t.Errorf("expected UTC (fallback), got %v", loc)
+	}
+
+	// Case 4: unknown device → returns nil
+	loc = server3.GetDeviceTimezone("NOSUCH")
+	if loc != nil {
+		t.Errorf("expected nil for unknown device, got %v", loc)
+	}
+}
+
+func TestGetDeviceTimezone_DeviceOverridesDefault(t *testing.T) {
+	istanbul, err := time.LoadLocation("Europe/Istanbul")
+	if err != nil {
+		t.Fatal(err)
+	}
+	berlin, err := time.LoadLocation("Europe/Berlin")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	server := NewADMSServer(WithDefaultTimezone(berlin))
+	defer server.Close()
+
+	if err := server.RegisterDevice("DEV001", WithDeviceTimezone(istanbul)); err != nil {
+		t.Fatalf("RegisterDevice failed: %v", err)
+	}
+
+	loc := server.GetDeviceTimezone("DEV001")
+	if loc == nil || loc.String() != "Europe/Istanbul" {
+		t.Errorf("expected device-specific Europe/Istanbul to override server default, got %v", loc)
+	}
+}
+
+func TestDeviceCopy_IncludesTimezone(t *testing.T) {
+	server := NewADMSServer()
+	defer server.Close()
+
+	tokyo, err := time.LoadLocation("Asia/Tokyo")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := server.RegisterDevice("DEV001", WithDeviceTimezone(tokyo)); err != nil {
+		t.Fatalf("RegisterDevice failed: %v", err)
+	}
+
+	dev := server.GetDevice("DEV001")
+	if dev.Timezone == nil || dev.Timezone.String() != "Asia/Tokyo" {
+		t.Errorf("expected copied device to have Asia/Tokyo, got %v", dev.Timezone)
+	}
+}
+
+func TestParseAttendance_DeviceTimezone(t *testing.T) {
+	istanbul, err := time.LoadLocation("Europe/Istanbul")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	server := NewADMSServer()
+	defer server.Close()
+
+	data := "123\t2024-06-15 09:00:00\t0\t15\t0"
+	records := server.parseAttendanceRecords(data, "DEV001", istanbul)
+	if len(records) != 1 {
+		t.Fatalf("expected 1 record, got %d", len(records))
+	}
+
+	rec := records[0]
+	// 09:00 Istanbul (UTC+3) = 06:00 UTC
+	expectedUTC := time.Date(2024, 6, 15, 6, 0, 0, 0, time.UTC)
+	if !rec.Timestamp.Equal(expectedUTC) {
+		t.Errorf("expected timestamp %v, got %v", expectedUTC, rec.Timestamp.UTC())
+	}
+}
+
+func TestParseAttendance_DefaultTimezone(t *testing.T) {
+	berlin, err := time.LoadLocation("Europe/Berlin")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	server := NewADMSServer()
+	defer server.Close()
+
+	data := "123\t2024-06-15 09:00:00\t0\t15\t0"
+	records := server.parseAttendanceRecords(data, "DEV001", berlin)
+	if len(records) != 1 {
+		t.Fatalf("expected 1 record, got %d", len(records))
+	}
+
+	rec := records[0]
+	// 09:00 Berlin (UTC+2 in summer CEST) = 07:00 UTC
+	expectedUTC := time.Date(2024, 6, 15, 7, 0, 0, 0, time.UTC)
+	if !rec.Timestamp.Equal(expectedUTC) {
+		t.Errorf("expected timestamp %v, got %v", expectedUTC, rec.Timestamp.UTC())
+	}
+}
+
+func TestParseAttendance_UTC_Fallback(t *testing.T) {
+	server := NewADMSServer()
+	defer server.Close()
+
+	data := "123\t2024-06-15 09:00:00\t0\t15\t0"
+	records := server.parseAttendanceRecords(data, "DEV001", time.UTC)
+	if len(records) != 1 {
+		t.Fatalf("expected 1 record, got %d", len(records))
+	}
+
+	rec := records[0]
+	expectedUTC := time.Date(2024, 6, 15, 9, 0, 0, 0, time.UTC)
+	if !rec.Timestamp.Equal(expectedUTC) {
+		t.Errorf("expected timestamp %v, got %v", expectedUTC, rec.Timestamp.UTC())
+	}
+}
+
+func TestParseAttendance_UnixEpoch_IgnoresLocation(t *testing.T) {
+	// Unix epoch timestamps are inherently UTC — location should not affect them.
+	istanbul, err := time.LoadLocation("Europe/Istanbul")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	server := NewADMSServer()
+	defer server.Close()
+
+	// 1718442000 = 2024-06-15 09:00:00 UTC
+	data := "123\t1718442000\t0\t15\t0"
+	records := server.parseAttendanceRecords(data, "DEV001", istanbul)
+	if len(records) != 1 {
+		t.Fatalf("expected 1 record, got %d", len(records))
+	}
+
+	rec := records[0]
+	expectedUTC := time.Date(2024, 6, 15, 9, 0, 0, 0, time.UTC)
+	if !rec.Timestamp.Equal(expectedUTC) {
+		t.Errorf("expected timestamp %v (unchanged by location), got %v", expectedUTC, rec.Timestamp.UTC())
+	}
+}
+
+func TestHandleCData_AttendanceUsesDeviceTimezone(t *testing.T) {
+	istanbul, err := time.LoadLocation("Europe/Istanbul")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	received := make(chan AttendanceRecord, 1)
+	server := NewADMSServer(
+		WithOnAttendance(func(_ context.Context, rec AttendanceRecord) {
+			received <- rec
+		}),
+	)
+	defer server.Close()
+
+	if err := server.RegisterDevice("DEV001", WithDeviceTimezone(istanbul)); err != nil {
+		t.Fatalf("RegisterDevice failed: %v", err)
+	}
+
+	data := "123\t2024-06-15 09:00:00\t0\t15\t0"
+	req := httptest.NewRequest(http.MethodPost,
+		"/iclock/cdata?SN=DEV001&table=ATTLOG", strings.NewReader(data))
+	w := httptest.NewRecorder()
+	server.HandleCData(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+
+	select {
+	case rec := <-received:
+		// 09:00 Istanbul (UTC+3) = 06:00 UTC
+		expectedUTC := time.Date(2024, 6, 15, 6, 0, 0, 0, time.UTC)
+		if !rec.Timestamp.Equal(expectedUTC) {
+			t.Errorf("expected %v, got %v", expectedUTC, rec.Timestamp.UTC())
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("timed out waiting for attendance callback")
+	}
+}
+
+func TestHandleCData_AttendanceUsesServerDefaultTimezone(t *testing.T) {
+	tokyo, err := time.LoadLocation("Asia/Tokyo")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	received := make(chan AttendanceRecord, 1)
+	server := NewADMSServer(
+		WithDefaultTimezone(tokyo),
+		WithOnAttendance(func(_ context.Context, rec AttendanceRecord) {
+			received <- rec
+		}),
+	)
+	defer server.Close()
+
+	// Device registered without explicit timezone — should use server default.
+	if err := server.RegisterDevice("DEV001"); err != nil {
+		t.Fatalf("RegisterDevice failed: %v", err)
+	}
+
+	data := "123\t2024-06-15 09:00:00\t0\t15\t0"
+	req := httptest.NewRequest(http.MethodPost,
+		"/iclock/cdata?SN=DEV001&table=ATTLOG", strings.NewReader(data))
+	w := httptest.NewRecorder()
+	server.HandleCData(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+
+	select {
+	case rec := <-received:
+		// 09:00 Tokyo (UTC+9) = 00:00 UTC
+		expectedUTC := time.Date(2024, 6, 15, 0, 0, 0, 0, time.UTC)
+		if !rec.Timestamp.Equal(expectedUTC) {
+			t.Errorf("expected %v, got %v", expectedUTC, rec.Timestamp.UTC())
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("timed out waiting for attendance callback")
+	}
+}
+
+func TestHandleCData_MultiDeviceDifferentTimezones(t *testing.T) {
+	istanbul, err := time.LoadLocation("Europe/Istanbul")
+	if err != nil {
+		t.Fatal(err)
+	}
+	tokyo, err := time.LoadLocation("Asia/Tokyo")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	received := make(chan AttendanceRecord, 2)
+	server := NewADMSServer(
+		WithOnAttendance(func(_ context.Context, rec AttendanceRecord) {
+			received <- rec
+		}),
+	)
+	defer server.Close()
+
+	if err := server.RegisterDevice("IST001", WithDeviceTimezone(istanbul)); err != nil {
+		t.Fatalf("RegisterDevice IST001 failed: %v", err)
+	}
+	if err := server.RegisterDevice("TKY001", WithDeviceTimezone(tokyo)); err != nil {
+		t.Fatalf("RegisterDevice TKY001 failed: %v", err)
+	}
+
+	// Both devices report "09:00:00" but in different timezones.
+	data := "123\t2024-06-15 09:00:00\t0\t15\t0"
+
+	req1 := httptest.NewRequest(http.MethodPost,
+		"/iclock/cdata?SN=IST001&table=ATTLOG", strings.NewReader(data))
+	w1 := httptest.NewRecorder()
+	server.HandleCData(w1, req1)
+
+	req2 := httptest.NewRequest(http.MethodPost,
+		"/iclock/cdata?SN=TKY001&table=ATTLOG", strings.NewReader(data))
+	w2 := httptest.NewRecorder()
+	server.HandleCData(w2, req2)
+
+	istanbulExpected := time.Date(2024, 6, 15, 6, 0, 0, 0, time.UTC) // UTC+3
+	tokyoExpected := time.Date(2024, 6, 15, 0, 0, 0, 0, time.UTC)    // UTC+9
+
+	results := make(map[string]time.Time)
+	for range 2 {
+		select {
+		case rec := <-received:
+			results[rec.SerialNumber] = rec.Timestamp.UTC()
+		case <-time.After(3 * time.Second):
+			t.Fatal("timed out waiting for attendance callbacks")
+		}
+	}
+
+	if !results["IST001"].Equal(istanbulExpected) {
+		t.Errorf("IST001: expected %v, got %v", istanbulExpected, results["IST001"])
+	}
+	if !results["TKY001"].Equal(tokyoExpected) {
+		t.Errorf("TKY001: expected %v, got %v", tokyoExpected, results["TKY001"])
+	}
+}
+
+func TestDeviceSnapshot_IncludesTimezone(t *testing.T) {
+	istanbul, err := time.LoadLocation("Europe/Istanbul")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	server := NewADMSServer(WithEnableInspect())
+	defer server.Close()
+
+	if err := server.RegisterDevice("DEV001", WithDeviceTimezone(istanbul)); err != nil {
+		t.Fatalf("RegisterDevice failed: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/iclock/inspect", nil)
+	w := httptest.NewRecorder()
+	server.HandleInspect(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+
+	var resp struct {
+		Devices []DeviceSnapshot `json:"devices"`
+	}
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+	if len(resp.Devices) != 1 {
+		t.Fatalf("expected 1 device, got %d", len(resp.Devices))
+	}
+	if resp.Devices[0].Timezone != "Europe/Istanbul" {
+		t.Errorf("expected timezone Europe/Istanbul in snapshot, got %q", resp.Devices[0].Timezone)
+	}
+}
+
+func TestDeviceSnapshot_DefaultTimezoneInSnapshot(t *testing.T) {
+	server := NewADMSServer(WithEnableInspect())
+	defer server.Close()
+
+	if err := server.RegisterDevice("DEV001"); err != nil {
+		t.Fatalf("RegisterDevice failed: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/iclock/inspect", nil)
+	w := httptest.NewRecorder()
+	server.HandleInspect(w, req)
+
+	var resp struct {
+		Devices []DeviceSnapshot `json:"devices"`
+	}
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+	if len(resp.Devices) != 1 {
+		t.Fatalf("expected 1 device, got %d", len(resp.Devices))
+	}
+	if resp.Devices[0].Timezone != "UTC" {
+		t.Errorf("expected UTC timezone in snapshot, got %q", resp.Devices[0].Timezone)
+	}
+}
+
+func TestWithDefaultTimezone(t *testing.T) {
+	berlin, err := time.LoadLocation("Europe/Berlin")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	server := NewADMSServer(WithDefaultTimezone(berlin))
+	defer server.Close()
+
+	if server.defaultTimezone.String() != "Europe/Berlin" {
+		t.Errorf("expected server default Europe/Berlin, got %s", server.defaultTimezone.String())
+	}
+}
+
+func TestWithDefaultTimezone_NilIgnored(t *testing.T) {
+	server := NewADMSServer(WithDefaultTimezone(nil))
+	defer server.Close()
+
+	if server.defaultTimezone.String() != "UTC" {
+		t.Errorf("expected UTC when nil passed, got %s", server.defaultTimezone.String())
+	}
+}
+
+func TestWithDeviceTimezone_NilSetsNil(t *testing.T) {
+	d := &Device{}
+	opt := WithDeviceTimezone(nil)
+	opt(d)
+	if d.Timezone != nil {
+		t.Errorf("expected nil timezone, got %v", d.Timezone)
+	}
+}
+
+func TestParseAttendance_WinterSummerTime(t *testing.T) {
+	// Verify DST transitions are handled correctly.
+	berlin, err := time.LoadLocation("Europe/Berlin")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	server := NewADMSServer()
+	defer server.Close()
+
+	// Winter time (CET = UTC+1): 2024-01-15 09:00:00 → 08:00 UTC
+	winter := "123\t2024-01-15 09:00:00\t0\t15\t0"
+	winterRecords := server.parseAttendanceRecords(winter, "DEV001", berlin)
+	if len(winterRecords) != 1 {
+		t.Fatalf("expected 1 record, got %d", len(winterRecords))
+	}
+	winterExpected := time.Date(2024, 1, 15, 8, 0, 0, 0, time.UTC)
+	if !winterRecords[0].Timestamp.Equal(winterExpected) {
+		t.Errorf("winter: expected %v, got %v", winterExpected, winterRecords[0].Timestamp.UTC())
+	}
+
+	// Summer time (CEST = UTC+2): 2024-07-15 09:00:00 → 07:00 UTC
+	summer := "123\t2024-07-15 09:00:00\t0\t15\t0"
+	summerRecords := server.parseAttendanceRecords(summer, "DEV001", berlin)
+	if len(summerRecords) != 1 {
+		t.Fatalf("expected 1 record, got %d", len(summerRecords))
+	}
+	summerExpected := time.Date(2024, 7, 15, 7, 0, 0, 0, time.UTC)
+	if !summerRecords[0].Timestamp.Equal(summerExpected) {
+		t.Errorf("summer: expected %v, got %v", summerExpected, summerRecords[0].Timestamp.UTC())
 	}
 }

--- a/examples/basic/main.go
+++ b/examples/basic/main.go
@@ -196,6 +196,7 @@ func statusHandler(server *zkadms.ADMSServer) http.Handler {
 			fmt.Fprintf(w, "Serial Number: %s\n", device.SerialNumber)
 			fmt.Fprintf(w, "Last Activity: %s\n", device.LastActivity.Format(time.RFC3339))
 			fmt.Fprintf(w, "Online: %t\n", online)
+			fmt.Fprintf(w, "Timezone: %s\n", server.GetDeviceTimezone(device.SerialNumber))
 			fmt.Fprintf(w, "Options: %v\n", device.Options)
 			fmt.Fprintln(w, "---")
 		}

--- a/examples/commands/main.go
+++ b/examples/commands/main.go
@@ -211,6 +211,7 @@ type deviceEntry struct {
 	LastActivity string            `json:"last_activity"`
 	Online       bool              `json:"online"`
 	Options      map[string]string `json:"options,omitzero"`
+	Timezone     string            `json:"timezone"`
 	PendingCmds  int               `json:"pending_commands"`
 }
 
@@ -594,6 +595,7 @@ func handleListDevices(server *zkadms.ADMSServer) http.Handler {
 				LastActivity: d.LastActivity.Format(time.RFC3339),
 				Online:       server.IsDeviceOnline(d.SerialNumber),
 				Options:      d.Options,
+				Timezone:     server.GetDeviceTimezone(d.SerialNumber).String(),
 				PendingCmds:  server.PendingCommandsCount(d.SerialNumber),
 			}
 		}
@@ -614,6 +616,7 @@ func handleDeviceDetail(server *zkadms.ADMSServer) http.Handler {
 			LastActivity: d.LastActivity.Format(time.RFC3339),
 			Online:       server.IsDeviceOnline(sn),
 			Options:      d.Options,
+			Timezone:     server.GetDeviceTimezone(sn).String(),
 			PendingCmds:  server.PendingCommandsCount(sn),
 		}
 		writeJSON(w, http.StatusOK, entry)


### PR DESCRIPTION
Replace time.Parse with time.ParseInLocation so attendance timestamps from ZKTeco devices are interpreted in the device's configured timezone instead of being silently treated as UTC.

- Add DeviceOption type and WithDeviceTimezone for per-device TZ config
- Add WithDefaultTimezone server option (defaults to time.UTC)
- Add SetDeviceTimezone/GetDeviceTimezone public APIs
- Add ErrDeviceNotFound sentinel error
- Extend RegisterDevice to accept variadic DeviceOption
- Add Timezone field to Device, DeviceSnapshot, and inspect endpoint
- Timezone fallback chain: device -> server default -> UTC
- Update examples to surface timezone in device listings
- Add 22 tests covering TZ parsing, fallback chain, DST, multi-device