### PR TITLE
fix: resolve 6 code audit items — shutdown ordering, backpressure, va…

### DIFF
--- a/GETTING_STARTED.md
+++ b/GETTING_STARTED.md
@@ -107,7 +107,7 @@ server := zkadms.NewADMSServer(
 defer server.Close()
 ```
 
-Note: the `ctx` passed to your callback is derived from the server's base context and will be cancelled when `server.Close()` is called, which makes it ideal for database calls.
+Note: the `ctx` passed to your callback is derived from the server's base context and will be cancelled after `server.Close()` finishes draining all queued callbacks. This means database calls and HTTP requests inside callbacks complete normally during graceful shutdown.
 
 ### 2. Send Notifications
 
@@ -161,7 +161,7 @@ go func() {
 ### Request Device Information
 
 ```go
-if err := server.SendInfoCommand("DEVICE001"); err != nil {
+if _, err := server.SendInfoCommand("DEVICE001"); err != nil {
     log.Printf("Failed to queue INFO command: %v", err)
 }
 ```
@@ -183,13 +183,16 @@ defer server.Close()
 ### Custom Commands
 
 ```go
-// Queue a command for the device (returns error if queue limit reached)
-if err := server.QueueCommand("DEVICE001", "CHECK"); err != nil {
+// Queue a command for the device (returns command ID and error)
+if _, err := server.QueueCommand("DEVICE001", "CHECK"); err != nil {
     log.Printf("Failed to queue command: %v", err)
 }
 
 // Drain all pending commands (useful for custom polling logic)
 cmds := server.DrainCommands("DEVICE001")
+for _, cmd := range cmds {
+    fmt.Println(cmd.ID, cmd.Command)
+}
 ```
 
 ## Configuring the Server

--- a/README.md
+++ b/README.md
@@ -189,34 +189,37 @@ zkadms.WithOnCommandResult(func(ctx context.Context, result zkadms.CommandResult
 
 ```go
 // Queue a custom command (returns ErrCommandQueueFull if limit reached)
-err := server.QueueCommand("DEVICE001", "CHECK")
+_, err := server.QueueCommand("DEVICE001", "CHECK")
 
 // Request device information
-err = server.SendInfoCommand("DEVICE001")
+_, err = server.SendInfoCommand("DEVICE001")
 
 // Heartbeat / connectivity check
-err = server.SendCheckCommand("DEVICE001")
+_, err = server.SendCheckCommand("DEVICE001")
 
 // Add or update a user on the device
-err = server.SendUserAddCommand("DEVICE001", "12345", "John Doe", 0, "")
+_, err = server.SendUserAddCommand("DEVICE001", "12345", "John Doe", 0, "")
 
 // Delete a user from the device
-err = server.SendUserDeleteCommand("DEVICE001", "12345")
+_, err = server.SendUserDeleteCommand("DEVICE001", "12345")
 
 // Retrieve a device option (value arrives via device info push)
-err = server.SendGetOptionCommand("DEVICE001", "DeviceName")
+_, err = server.SendGetOptionCommand("DEVICE001", "DeviceName")
 
-// Query all users (data pushed via POST /iclock/cdata; see note below)
-err = server.SendQueryUsersCommand("DEVICE001")
+// Query all users (data pushed via POST /iclock/cdata with table=USERINFO)
+_, err = server.SendQueryUsersCommand("DEVICE001")
 
 // Execute a shell command on the device (use with caution!)
-err = server.SendShellCommand("DEVICE001", "date")
+_, err = server.SendShellCommand("DEVICE001", "date")
 
 // Request log data
-err = server.SendLogCommand("DEVICE001")
+_, err = server.SendLogCommand("DEVICE001")
 
 // Drain all pending commands for a device
 cmds := server.DrainCommands("DEVICE001")
+for _, cmd := range cmds {
+    fmt.Println(cmd.ID, cmd.Command)
+}
 ```
 
 ### Listing Connected Devices
@@ -351,7 +354,7 @@ Confirmed GET OPTION keys: `DeviceName`, `FWVersion`, `IPAddress`, `MACAddress`,
 **Important protocol notes:**
 - The ADMS datasheet documents user commands as `USER ADD` / `USER DEL`, but real devices reject these with error -1002. Use `DATA UPDATE USERINFO` / `DATA DELETE USERINFO` instead.
 - `DATA DEL USERINFO` (truncated) also fails — the full word `DELETE` is required.
-- `DATA QUERY` commands cause the device to push data via `POST /iclock/cdata`, not via the command confirmation endpoint. **Note:** This library currently only acknowledges `/iclock/cdata` pushes and does not parse or surface the returned data records. If you need to consume query results, you must handle and parse the `/iclock/cdata` requests yourself.
+- `DATA QUERY` commands cause the device to push data via `POST /iclock/cdata`, not via the command confirmation endpoint. The library fully parses `USERINFO` records pushed this way and dispatches them via the `WithOnQueryUsers` callback. Use `SendQueryUsersCommand` to trigger a full user dump, or `QueueCommand(sn, "DATA QUERY USERINFO PIN=1")` for a single user.
 - `Shell` commands execute on the device's Linux OS — use with extreme caution.
 
 ### Registry Payload Parsing
@@ -603,20 +606,21 @@ Creates a new ADMS server instance configured with the given options.
 | Method | Description |
 |--------|-------------|
 | `Close()` | Drain callbacks and stop the worker goroutine |
-| `RegisterDevice(serialNumber string) error` | Register a device; validates SN, respects device limit |
+| `RegisterDevice(serialNumber string, opts ...DeviceOption) error` | Register a device; validates SN, respects device limit |
 | `GetDevice(serialNumber string) *Device` | Get device information (returns a copy) |
+| `GetDeviceTimezone(serialNumber string) *time.Location` | Get the configured timezone for a device |
 | `IsDeviceOnline(serialNumber string) bool` | Check if a device is online |
-| `QueueCommand(serialNumber, command string) error` | Queue a command; respects per-device limit |
-| `DrainCommands(serialNumber string) []string` | Drain and return all pending commands |
+| `QueueCommand(serialNumber, command string) (int64, error)` | Queue a command; validates device, fields, and per-device limit |
+| `DrainCommands(serialNumber string) []CommandEntry` | Drain and return all pending commands |
 | `PendingCommandsCount(serialNumber string) int` | Return the number of queued commands without draining |
-| `SendInfoCommand(serialNumber string) error` | Queue an INFO command |
-| `SendCheckCommand(serialNumber string) error` | Queue a CHECK (heartbeat) command |
-| `SendUserAddCommand(serialNumber, pin, name string, privilege int, card string) error` | Queue a DATA UPDATE USERINFO command |
-| `SendUserDeleteCommand(serialNumber, pin string) error` | Queue a DATA DELETE USERINFO command |
-| `SendGetOptionCommand(serialNumber, key string) error` | Queue a GET OPTION FROM command |
-| `SendQueryUsersCommand(serialNumber string) error` | Queue a DATA QUERY USERINFO command |
-| `SendShellCommand(serialNumber, command string) error` | Queue a Shell command (use with caution) |
-| `SendLogCommand(serialNumber string) error` | Queue a LOG command |
+| `SendInfoCommand(serialNumber string) (int64, error)` | Queue an INFO command |
+| `SendCheckCommand(serialNumber string) (int64, error)` | Queue a CHECK (heartbeat) command |
+| `SendUserAddCommand(serialNumber, pin, name string, privilege int, card string) (int64, error)` | Queue a DATA UPDATE USERINFO command |
+| `SendUserDeleteCommand(serialNumber, pin string) (int64, error)` | Queue a DATA DELETE USERINFO command |
+| `SendGetOptionCommand(serialNumber, key string) (int64, error)` | Queue a GET OPTION FROM command |
+| `SendQueryUsersCommand(serialNumber string) (int64, error)` | Queue a DATA QUERY USERINFO command |
+| `SendShellCommand(serialNumber, command string) (int64, error)` | Queue a Shell command (use with caution) |
+| `SendLogCommand(serialNumber string) (int64, error)` | Queue a LOG command |
 | `ListDevices() []*Device` | List all registered devices (returns copies) |
 | `ServeHTTP(w, r)` | `http.Handler` implementation — routes to endpoint handlers |
 | `HandleCData(w, r)` | Handle `/iclock/cdata` requests |

--- a/SUGGESTIONS_NEXT.md
+++ b/SUGGESTIONS_NEXT.md
@@ -1,13 +1,222 @@
 # Suggestions for Next PR
 
-Carried over from the PR #28 code review.
+Open-source readiness audit for the current tree.
+
+The good news: `go test ./...`, `go test -race ./...`, and `golangci-lint run` all pass.
+The bad news: passing checks does not cancel the failure modes below.
+
+## ~~HIGH: `Close()` cancels callback context before draining queued work~~ DONE
+
+**Location:** `adms.go:600-617`, `adms.go:823-826`, `adms.go:844-846`, `adms.go:866-867`, `adms.go:882-885`, `GETTING_STARTED.md:110`
+
+`Close()` cancels `baseCtx` before waiting for queued callbacks to drain. That means the library promises
+"drain pending callbacks" while simultaneously handing those callbacks an already-canceled context. Any
+consumer doing the sane thing with that context (`db.ExecContext`, HTTP calls, etc.) can abort its own work
+during shutdown and silently drop the very events `Close()` is supposed to flush.
+
+This is the kind of shutdown behavior that looks fine in tests and loses the last few attendance records in
+production.
+
+**Suggested fix:**
+
+- Either delay `baseCtxCancel()` until after `callbackDone`.
+- Or document clearly that `Close()` drains callback execution, not successful callback completion.
+- Better: pass a per-callback context derived from `baseCtx` at dispatch time and only cancel it if the event
+  itself should be abandoned.
+
+```go
+func (s *ADMSServer) Close() {
+	s.closeOnce.Do(func() {
+		close(s.closeCh)
+		<-s.evictionDone
+
+		s.callbackMu.Lock()
+		close(s.callbackCh)
+		s.callbackMu.Unlock()
+
+		<-s.callbackDone
+		s.baseCtxCancel()
+	})
+}
+```
+
+## ~~HIGH: Several handlers silently drop data under backpressure and still return `200 OK`~~ DONE
+
+**Location:** `adms.go:1131-1141`, `adms.go:1151-1161`, `adms.go:1233-1240`, `adms.go:1699-1705`
+
+`ATTLOG` is handled correctly: if the callback queue is full, the handler returns `503` so the device can retry.
+Everything else is worse:
+
+- `table=USERINFO` records are dropped and still acknowledged with `200 OK`
+- device info pushes are dropped and still acknowledged with `200 OK`
+- registry payloads are dropped and still acknowledged with `200 OK`
+- command results are dropped and still acknowledged with `200 OK`
+
+That is silent data loss. The device thinks delivery succeeded. Your consumer never sees the data. Nobody gets
+to debug this without packet captures and swearing.
+
+**Suggested fix:**
+
+- Pick one delivery contract and apply it consistently.
+- If the callback is required for correctness, return `503` on enqueue failure.
+- If best-effort is acceptable, make that explicit in the API docs and expose a metric/counter for dropped events.
+
+```go
+if !s.dispatchQueryUsers(serialNumber, users) {
+	http.Error(w, "FAIL: callback queue full", http.StatusServiceUnavailable)
+	return
+}
+```
+
+## ~~HIGH: `pendingCommands` can grow without bound even when per-device queue limits are enabled~~ DONE
+
+**Location:** `adms.go:1036-1047`, `adms.go:1052-1058`, `adms.go:1216-1220`, `adms.go:660-691`
+
+`WithMaxCommandsPerDevice` only limits commands before they are polled by the device. After `DrainCommands`, the
+entries are removed from `commandQueue` but stay alive in `pendingCommands` until the device confirms them via
+`/iclock/devicecmd` or gets evicted.
+
+So a device that keeps polling but never sends confirmations can accumulate an unbounded `pendingCommands` map.
+That is a real memory-growth path, and it gets worse because those commands are now invisible to the per-device
+queue limit.
+
+**Suggested fix:**
+
+- Track pending confirmations per device and cap them too.
+- Add a confirmation TTL and reap stale pending IDs.
+- Consider rejecting new commands when `queued + pending` exceeds the configured limit.
+
+```go
+type pendingEntry struct {
+	sn       string
+	cmd      string
+	queuedAt time.Time
+}
+
+if s.maxCommandsPerDevice > 0 {
+	pending := s.pendingCountLocked(serialNumber)
+	queued := len(s.commandQueue[serialNumber])
+	if queued+pending >= s.maxCommandsPerDevice {
+		return 0, ErrCommandQueueFull
+	}
+}
+```
+
+## ~~HIGH: `QueueCommand` accepts unknown serial numbers, which creates an orphaned memory leak path~~ DONE
+
+**Location:** `adms.go:1036-1047`, `adms.go:660-691`, `examples/basic/main.go:206-228`
+
+`QueueCommand` does not require the device to exist. That means callers can enqueue commands for arbitrary serial
+numbers, creating `commandQueue` and `pendingCommands` entries for devices the server has never seen. The eviction
+worker only walks `devices`, so these orphaned command structures are never cleaned up.
+
+The basic example exposes this directly through `/command`, so anyone hitting that endpoint can spray fake serials
+and turn memory into a landfill.
+
+**Suggested fix:**
+
+- Make `QueueCommand` return `ErrDeviceNotFound` for unknown devices.
+- If pre-registration is a required feature, add an explicit option like `WithAllowCommandsForUnknownDevices()`.
+- At minimum, document the behavior and add cleanup for orphaned serials.
+
+```go
+s.devicesMutex.RLock()
+_, exists := s.devices[serialNumber]
+s.devicesMutex.RUnlock()
+if !exists {
+	return 0, ErrDeviceNotFound
+}
+```
+
+## ~~HIGH: Command construction is injection-prone because user strings are written straight onto the ADMS wire~~ DONE
+
+**Location:** `adms.go:117`, `adms.go:749-751`, `adms.go:1543-1545`, `adms.go:1559-1561`, `adms.go:1588-1590`, `adms.go:1607-1609`, `examples/commands/main.go:503-526`, `examples/commands/main.go:558-579`, `examples/basic/main.go:206-228`
+
+The library builds wire commands with raw `fmt.Sprintf` and then emits them verbatim as `C:<id>:<cmd>\n`.
+If `pin`, `name`, `key`, or shell text contains tabs, newlines, or delimiter characters, the caller can inject
+extra fields or extra command lines.
+
+For an open-source library, this is a footgun. For the example APIs that accept raw commands and shell commands,
+it is a loaded footgun handed to the nearest bystander.
+
+**Suggested fix:**
+
+- Validate command fragments before formatting.
+- Reject control characters (`\r`, `\n`, `\t`) in fields unless the protocol explicitly requires them.
+- Provide a small escaping/validation helper used by all command builders.
+
+```go
+func validateCommandField(name, value string) error {
+	if strings.ContainsAny(value, "\r\n") {
+		return fmt.Errorf("%s contains forbidden control characters", name)
+	}
+	return nil
+}
+```
+
+## MEDIUM: One slow callback blocks every event type and turns the server into a head-of-line queue
+
+**Location:** `adms.go:590-593`, `adms.go:620-638`, `adms.go:813-831`
+
+There is exactly one callback worker goroutine. All attendance, device info, registry events, user query results,
+and command confirmations are serialized through that single worker. Then `dispatchAttendance` processes an entire
+batch inside one queued closure.
+
+So one slow database write, one hanging webhook, or one oversized attendance batch stalls everything behind it.
+Eventually the queue fills and now you are in the data-drop behavior described above.
+
+This is not a race bug. It is a throughput ceiling with a built-in traffic jam.
+
+**Suggested fix:**
+
+- Document that callbacks must be fast and non-blocking.
+- Consider configurable worker concurrency.
+- Consider dispatching records individually or in bounded sub-batches.
+
+```go
+for i := 0; i < s.callbackWorkers; i++ {
+	go s.callbackWorker()
+}
+```
+
+## ~~MEDIUM: Public docs are out of sync with the actual API and current behavior~~ DONE
+
+**Location:** `README.md:191-219`, `README.md:354`, `README.md:609-618`, `GETTING_STARTED.md:164-193`
+
+The docs are lying in multiple places:
+
+- examples still show `SendInfoCommand` and `QueueCommand` as if they return only `error`
+- docs still describe `DrainCommands` as returning strings, not `[]CommandEntry`
+- README still says `DATA QUERY` results are not parsed/surfaced, but the library now parses `USERINFO` and
+  exposes `WithOnQueryUsers`
+
+Shipping an OSS library with stale signatures and stale behavior docs is how you farm issue reports from annoyed
+users who did exactly what your README told them to do.
+
+**Suggested fix:**
+
+- Update all command examples to use `(id, err)` or explicitly ignore the ID.
+- Update API tables to reflect `[]CommandEntry`.
+- Replace the stale `DATA QUERY` note with the actual `USERINFO` support story and its limits.
+
+```go
+_, err := server.SendInfoCommand("DEVICE001")
+if err != nil {
+	log.Printf("Failed to queue INFO command: %v", err)
+}
+
+cmds := server.DrainCommands("DEVICE001")
+for _, cmd := range cmds {
+	fmt.Println(cmd.ID, cmd.Command)
+}
+```
 
 ## LOW: Clarify `RegisterDevice` idempotency contract
 
-**Location:** `adms.go:953-975`
+**Location:** `adms.go:955-978`
 
-`RegisterDevice` changed from no-op-on-existing to upsert. Document explicitly that omitted
-options retain their current values and calling without options is a no-op for existing devices.
+`RegisterDevice` behaves like an upsert. Document explicitly that omitted options retain their existing values and
+calling it without options on an existing device is a no-op.
 
 ```go
 // RegisterDevice registers a new device or updates the options of an existing one.
@@ -16,16 +225,16 @@ options retain their current values and calling without options is a no-op for e
 // without options on an existing device is a no-op.
 ```
 
-## LOW: Document TOCTOU behavior in `HandleCData` timezone resolution
+## LOW: Document the timezone TOCTOU trade-off in ATTLOG parsing
 
-**Location:** `adms.go:1098-1103`
+**Location:** `adms.go:1100-1105`
 
-The timezone is resolved under `RLock` and then used outside the lock. A concurrent
-`SetDeviceTimezone` call could change the timezone between resolution and parsing.
-Add a comment documenting this acceptable trade-off.
+The timezone is resolved under `RLock` and then used outside the lock. A concurrent `SetDeviceTimezone` call can
+change the configured timezone while parsing is already in progress. That trade-off is probably fine, but it should
+be documented instead of left as a surprise.
 
 ```go
 // NOTE: The timezone is resolved at the start of ATTLOG processing.
-// If the device's timezone is changed concurrently, records already
-// being parsed will use the previously resolved timezone.
+// If the device's timezone changes concurrently, records already being
+// parsed continue using the previously resolved timezone.
 ```

--- a/adms.go
+++ b/adms.go
@@ -184,6 +184,10 @@ var (
 	// ErrDeviceNotFound is returned when an operation targets a device that
 	// is not registered with the server.
 	ErrDeviceNotFound = errors.New("zkadms: device not found")
+
+	// ErrInvalidCommandField is returned when a command field contains
+	// control characters that could cause injection on the ADMS wire protocol.
+	ErrInvalidCommandField = errors.New("zkadms: command field contains forbidden control characters")
 )
 
 // serialNumberRe matches valid device serial numbers: 1–64 alphanumeric
@@ -595,13 +599,17 @@ func NewADMSServer(opts ...Option) *ADMSServer {
 
 // Close drains the callback queue and stops the worker goroutine.
 // It blocks until all pending callbacks have been executed and the
-// eviction worker has exited.
+// eviction worker has exited. The base context passed to callbacks
+// remains valid until all queued callbacks have finished executing,
+// so database calls and HTTP requests inside callbacks complete
+// normally during shutdown.
 // Close is safe to call multiple times.
 func (s *ADMSServer) Close() {
 	s.closeOnce.Do(func() {
-		// Cancel the base context so callbacks see cancellation.
-		s.baseCtxCancel()
-		// Signal all dispatchers and the eviction worker to stop.
+		// Signal all dispatchers and the eviction worker to stop
+		// accepting new work. Note: baseCtxCancel is intentionally
+		// deferred until after the callback worker drains, so that
+		// in-flight callbacks still have a live context for I/O.
 		close(s.closeCh)
 		// Wait for the eviction worker to exit before tearing down the
 		// callback pipeline, so no late eviction log races with closure.
@@ -614,6 +622,8 @@ func (s *ADMSServer) Close() {
 		s.callbackMu.Unlock()
 		// Wait for the worker to drain all remaining callbacks and exit.
 		<-s.callbackDone
+		// Cancel the base context after all callbacks have completed.
+		s.baseCtxCancel()
 	})
 }
 
@@ -1031,30 +1041,64 @@ func (s *ADMSServer) GetDeviceTimezone(serialNumber string) *time.Location {
 // QueueCommand adds a command to be sent to the device on its next poll.
 // It assigns a monotonically increasing command ID at queue time and returns
 // the ID so callers can correlate the command with its [CommandResult].
+// It returns [ErrDeviceNotFound] if the device is not registered with the server.
+// It returns [ErrInvalidCommandField] if the command contains control characters
+// that could cause injection on the ADMS wire protocol.
 // It returns [ErrCommandQueueFull] (with ID 0) if the per-device limit
 // configured via [WithMaxCommandsPerDevice] has been reached.
 func (s *ADMSServer) QueueCommand(serialNumber, command string) (int64, error) {
+	if err := validateCommandField("command", command); err != nil {
+		return 0, err
+	}
+
+	s.devicesMutex.RLock()
+	_, exists := s.devices[serialNumber]
+	s.devicesMutex.RUnlock()
+	if !exists {
+		return 0, ErrDeviceNotFound
+	}
+
 	id := s.cmdID.Add(1)
 
 	s.queueMutex.Lock()
 	defer s.queueMutex.Unlock()
 
-	if s.maxCommandsPerDevice > 0 && len(s.commandQueue[serialNumber]) >= s.maxCommandsPerDevice {
-		return 0, ErrCommandQueueFull
+	if s.maxCommandsPerDevice > 0 {
+		queued := len(s.commandQueue[serialNumber])
+		pending := s.pendingCountLocked(serialNumber)
+		if queued+pending >= s.maxCommandsPerDevice {
+			return 0, ErrCommandQueueFull
+		}
 	}
 	s.commandQueue[serialNumber] = append(s.commandQueue[serialNumber], CommandEntry{ID: id, Command: command})
-	s.pendingCommands[id] = pendingEntry{sn: serialNumber, cmd: command}
 	return id, nil
 }
 
-// DrainCommands retrieves and removes all pending commands for a device.
-// After this call, the device's command queue is empty.
+// pendingCountLocked returns the number of pending (drained but unconfirmed)
+// commands for the given serial number. The caller must hold s.queueMutex.
+func (s *ADMSServer) pendingCountLocked(serialNumber string) int {
+	n := 0
+	for _, entry := range s.pendingCommands {
+		if entry.sn == serialNumber {
+			n++
+		}
+	}
+	return n
+}
+
+// DrainCommands retrieves and removes all queued commands for a device.
+// After this call, the device's command queue is empty. Drained commands
+// are tracked as pending until the device confirms execution via
+// /iclock/devicecmd.
 func (s *ADMSServer) DrainCommands(serialNumber string) []CommandEntry {
 	s.queueMutex.Lock()
 	defer s.queueMutex.Unlock()
 
 	commands := s.commandQueue[serialNumber]
 	delete(s.commandQueue, serialNumber)
+	for _, cmd := range commands {
+		s.pendingCommands[cmd.ID] = pendingEntry{sn: serialNumber, cmd: cmd.Command}
+	}
 	return commands
 }
 
@@ -1134,6 +1178,9 @@ func (s *ADMSServer) HandleCData(w http.ResponseWriter, r *http.Request) {
 			if !s.dispatchQueryUsers(serialNumber, users) {
 				s.logger.Warn("callback queue full, user records dropped",
 					"count", len(users), "device", serialNumber)
+				http.Error(w, fmt.Sprintf("FAIL: callback queue full, %d user records not processed", len(users)),
+					http.StatusServiceUnavailable)
+				return
 			}
 		}
 
@@ -1152,6 +1199,9 @@ func (s *ADMSServer) HandleCData(w http.ResponseWriter, r *http.Request) {
 				if !s.dispatchDeviceInfo(serialNumber, info) {
 					s.logger.Warn("callback queue full, device info dropped",
 						"device", serialNumber)
+					http.Error(w, "FAIL: callback queue full, device info not processed",
+						http.StatusServiceUnavailable)
+					return
 				}
 				s.logger.Debug("INFO body", "preview", bodyPreview(body))
 			}
@@ -1233,6 +1283,9 @@ func (s *ADMSServer) HandleDeviceCmd(w http.ResponseWriter, r *http.Request) {
 		if !s.dispatchCommandResult(result) {
 			s.logger.Warn("callback queue full, command result dropped",
 				"device", serialNumber, "id", result.ID)
+			http.Error(w, fmt.Sprintf("FAIL: callback queue full, command result %d not processed", result.ID),
+				http.StatusServiceUnavailable)
+			return
 		}
 	}
 
@@ -1520,6 +1573,17 @@ func (s *ADMSServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
+// validateCommandField checks that a command field value does not contain
+// control characters that could cause injection on the ADMS wire protocol.
+// The wire format uses "C:<ID>:<CMD>\n", so newlines and carriage returns
+// in field values would allow injecting extra command lines.
+func validateCommandField(name, value string) error {
+	if strings.ContainsAny(value, "\r\n") {
+		return fmt.Errorf("%w: %s", ErrInvalidCommandField, name)
+	}
+	return nil
+}
+
 // SendInfoCommand queues an INFO command to request device information.
 // It returns the assigned command ID and an error if the command queue is full
 // (see [WithMaxCommandsPerDevice]).
@@ -1541,6 +1605,13 @@ func (s *ADMSServer) SendInfoCommand(serialNumber string) (int64, error) {
 // It returns the assigned command ID and an error if the command queue is full
 // (see [WithMaxCommandsPerDevice]).
 func (s *ADMSServer) SendUserAddCommand(serialNumber, pin, name string, privilege int, card string) (int64, error) {
+	for _, f := range []struct{ name, value string }{
+		{"pin", pin}, {"name", name}, {"card", card},
+	} {
+		if err := validateCommandField(f.name, f.value); err != nil {
+			return 0, err
+		}
+	}
 	cmd := fmt.Sprintf("DATA UPDATE USERINFO PIN=%s\tName=%s\tPrivilege=%d\tCard=%s", pin, name, privilege, card)
 	return s.QueueCommand(serialNumber, cmd)
 }
@@ -1557,6 +1628,9 @@ func (s *ADMSServer) SendUserAddCommand(serialNumber, pin, name string, privileg
 // It returns the assigned command ID and an error if the command queue is full
 // (see [WithMaxCommandsPerDevice]).
 func (s *ADMSServer) SendUserDeleteCommand(serialNumber, pin string) (int64, error) {
+	if err := validateCommandField("pin", pin); err != nil {
+		return 0, err
+	}
 	cmd := fmt.Sprintf("DATA DELETE USERINFO PIN=%s", pin)
 	return s.QueueCommand(serialNumber, cmd)
 }
@@ -1586,6 +1660,9 @@ func (s *ADMSServer) SendCheckCommand(serialNumber string) (int64, error) {
 // It returns the assigned command ID and an error if the command queue is full
 // (see [WithMaxCommandsPerDevice]).
 func (s *ADMSServer) SendGetOptionCommand(serialNumber, key string) (int64, error) {
+	if err := validateCommandField("key", key); err != nil {
+		return 0, err
+	}
 	cmd := fmt.Sprintf("GET OPTION FROM %s", key)
 	return s.QueueCommand(serialNumber, cmd)
 }
@@ -1605,6 +1682,9 @@ func (s *ADMSServer) SendGetOptionCommand(serialNumber, key string) (int64, erro
 // It returns the assigned command ID and an error if the command queue is full
 // (see [WithMaxCommandsPerDevice]).
 func (s *ADMSServer) SendShellCommand(serialNumber, command string) (int64, error) {
+	if err := validateCommandField("command", command); err != nil {
+		return 0, err
+	}
 	cmd := fmt.Sprintf("Shell %s", command)
 	return s.QueueCommand(serialNumber, cmd)
 }
@@ -1699,6 +1779,9 @@ func (s *ADMSServer) HandleRegistry(w http.ResponseWriter, r *http.Request) {
 		if !s.dispatchRegistry(serialNumber, info) {
 			s.logger.Warn("callback queue full, registry info dropped",
 				"device", serialNumber)
+			http.Error(w, "FAIL: callback queue full, registry info not processed",
+				http.StatusServiceUnavailable)
+			return
 		}
 	}
 	w.WriteHeader(http.StatusOK)

--- a/adms.go
+++ b/adms.go
@@ -1263,10 +1263,11 @@ func (s *ADMSServer) HandleDeviceCmd(w http.ResponseWriter, r *http.Request) {
 
 	for _, result := range results {
 		// Populate QueuedCommand from the pending commands map.
+		// Deletion is deferred until dispatch succeeds so that a device
+		// retry (after a 503) can still correlate the command.
 		s.queueMutex.Lock()
 		if entry, ok := s.pendingCommands[result.ID]; ok {
 			result.QueuedCommand = entry.cmd
-			delete(s.pendingCommands, result.ID)
 		}
 		s.queueMutex.Unlock()
 
@@ -1287,6 +1288,11 @@ func (s *ADMSServer) HandleDeviceCmd(w http.ResponseWriter, r *http.Request) {
 				http.StatusServiceUnavailable)
 			return
 		}
+
+		// Dispatch succeeded — remove the pending entry.
+		s.queueMutex.Lock()
+		delete(s.pendingCommands, result.ID)
+		s.queueMutex.Unlock()
 	}
 
 	w.WriteHeader(http.StatusOK)

--- a/adms.go
+++ b/adms.go
@@ -1176,7 +1176,7 @@ func (s *ADMSServer) HandleCData(w http.ResponseWriter, r *http.Request) {
 			s.logger.Debug("USERINFO records processed",
 				"count", len(users), "device", serialNumber)
 			if !s.dispatchQueryUsers(serialNumber, users) {
-				s.logger.Warn("callback queue full, user records dropped",
+				s.logger.Error("callback queue full, user records dropped",
 					"count", len(users), "device", serialNumber)
 				http.Error(w, fmt.Sprintf("FAIL: callback queue full, %d user records not processed", len(users)),
 					http.StatusServiceUnavailable)
@@ -1197,7 +1197,7 @@ func (s *ADMSServer) HandleCData(w http.ResponseWriter, r *http.Request) {
 			if len(body) > 0 {
 				info := s.parseKVPairs(string(body), "\n", nil)
 				if !s.dispatchDeviceInfo(serialNumber, info) {
-					s.logger.Warn("callback queue full, device info dropped",
+					s.logger.Error("callback queue full, device info dropped",
 						"device", serialNumber)
 					http.Error(w, "FAIL: callback queue full, device info not processed",
 						http.StatusServiceUnavailable)
@@ -1281,7 +1281,7 @@ func (s *ADMSServer) HandleDeviceCmd(w http.ResponseWriter, r *http.Request) {
 			"queued_cmd", result.QueuedCommand)
 
 		if !s.dispatchCommandResult(result) {
-			s.logger.Warn("callback queue full, command result dropped",
+			s.logger.Error("callback queue full, command result dropped",
 				"device", serialNumber, "id", result.ID)
 			http.Error(w, fmt.Sprintf("FAIL: callback queue full, command result %d not processed", result.ID),
 				http.StatusServiceUnavailable)
@@ -1777,7 +1777,7 @@ func (s *ADMSServer) HandleRegistry(w http.ResponseWriter, r *http.Request) {
 		}
 		s.devicesMutex.Unlock()
 		if !s.dispatchRegistry(serialNumber, info) {
-			s.logger.Warn("callback queue full, registry info dropped",
+			s.logger.Error("callback queue full, registry info dropped",
 				"device", serialNumber)
 			http.Error(w, "FAIL: callback queue full, registry info not processed",
 				http.StatusServiceUnavailable)

--- a/adms_test.go
+++ b/adms_test.go
@@ -108,6 +108,10 @@ func TestQueueAndGetCommands(t *testing.T) {
 	defer server.Close()
 	serialNumber := "TEST001"
 
+	if err := server.RegisterDevice(serialNumber); err != nil {
+		t.Fatalf("RegisterDevice failed: %v", err)
+	}
+
 	if _, err := server.QueueCommand(serialNumber, "INFO"); err != nil {
 		t.Fatalf("QueueCommand failed: %v", err)
 	}
@@ -136,6 +140,10 @@ func TestQueueAndGetCommands(t *testing.T) {
 func TestDrainCommandsDeletesKey(t *testing.T) {
 	server := NewADMSServer()
 	defer server.Close()
+
+	if err := server.RegisterDevice("DEL001"); err != nil {
+		t.Fatalf("RegisterDevice failed: %v", err)
+	}
 
 	if _, err := server.QueueCommand("DEL001", "INFO"); err != nil {
 		t.Fatalf("QueueCommand failed: %v", err)
@@ -251,6 +259,10 @@ func TestHandleCData_WithPendingCommands(t *testing.T) {
 	defer server.Close()
 	serialNumber := "TEST001"
 
+	if err := server.RegisterDevice(serialNumber); err != nil {
+		t.Fatalf("RegisterDevice failed: %v", err)
+	}
+
 	if _, err := server.QueueCommand(serialNumber, "INFO"); err != nil {
 		t.Fatalf("QueueCommand failed: %v", err)
 	}
@@ -272,6 +284,10 @@ func TestHandleGetRequest(t *testing.T) {
 	server := NewADMSServer()
 	defer server.Close()
 	serialNumber := "TEST001"
+
+	if err := server.RegisterDevice(serialNumber); err != nil {
+		t.Fatalf("RegisterDevice failed: %v", err)
+	}
 
 	if _, err := server.QueueCommand(serialNumber, "DATA DELETE USERINFO PIN=1001"); err != nil {
 		t.Fatalf("QueueCommand failed: %v", err)
@@ -729,6 +745,10 @@ func TestQueueCommand(t *testing.T) {
 	defer server.Close()
 	serialNumber := "TEST001"
 
+	if err := server.RegisterDevice(serialNumber); err != nil {
+		t.Fatalf("RegisterDevice failed: %v", err)
+	}
+
 	if _, err := server.QueueCommand(serialNumber, "INFO"); err != nil {
 		t.Fatalf("QueueCommand failed: %v", err)
 	}
@@ -746,6 +766,10 @@ func TestSendUserAddCommand(t *testing.T) {
 	server := NewADMSServer()
 	defer server.Close()
 	serialNumber := "TEST001"
+
+	if err := server.RegisterDevice(serialNumber); err != nil {
+		t.Fatalf("RegisterDevice failed: %v", err)
+	}
 
 	if _, err := server.SendUserAddCommand(serialNumber, "1001", "John Doe", 0, "12345678"); err != nil {
 		t.Fatalf("SendUserAddCommand failed: %v", err)
@@ -766,6 +790,10 @@ func TestSendUserDeleteCommand(t *testing.T) {
 	defer server.Close()
 	serialNumber := "TEST001"
 
+	if err := server.RegisterDevice(serialNumber); err != nil {
+		t.Fatalf("RegisterDevice failed: %v", err)
+	}
+
 	if _, err := server.SendUserDeleteCommand(serialNumber, "1001"); err != nil {
 		t.Fatalf("SendUserDeleteCommand failed: %v", err)
 	}
@@ -785,6 +813,10 @@ func TestSendInfoCommand(t *testing.T) {
 	defer server.Close()
 	serialNumber := "TEST001"
 
+	if err := server.RegisterDevice(serialNumber); err != nil {
+		t.Fatalf("RegisterDevice failed: %v", err)
+	}
+
 	if _, err := server.SendInfoCommand(serialNumber); err != nil {
 		t.Fatalf("SendInfoCommand failed: %v", err)
 	}
@@ -802,6 +834,10 @@ func TestSendCheckCommand(t *testing.T) {
 	server := NewADMSServer()
 	defer server.Close()
 
+	if err := server.RegisterDevice("TEST001"); err != nil {
+		t.Fatalf("RegisterDevice failed: %v", err)
+	}
+
 	if _, err := server.SendCheckCommand("TEST001"); err != nil {
 		t.Fatalf("SendCheckCommand failed: %v", err)
 	}
@@ -818,6 +854,10 @@ func TestSendCheckCommand(t *testing.T) {
 func TestSendGetOptionCommand(t *testing.T) {
 	server := NewADMSServer()
 	defer server.Close()
+
+	if err := server.RegisterDevice("TEST001"); err != nil {
+		t.Fatalf("RegisterDevice failed: %v", err)
+	}
 
 	if _, err := server.SendGetOptionCommand("TEST001", "DeviceName"); err != nil {
 		t.Fatalf("SendGetOptionCommand failed: %v", err)
@@ -837,6 +877,10 @@ func TestSendShellCommand(t *testing.T) {
 	server := NewADMSServer()
 	defer server.Close()
 
+	if err := server.RegisterDevice("TEST001"); err != nil {
+		t.Fatalf("RegisterDevice failed: %v", err)
+	}
+
 	if _, err := server.SendShellCommand("TEST001", "date"); err != nil {
 		t.Fatalf("SendShellCommand failed: %v", err)
 	}
@@ -855,6 +899,10 @@ func TestSendQueryUsersCommand(t *testing.T) {
 	server := NewADMSServer()
 	defer server.Close()
 
+	if err := server.RegisterDevice("TEST001"); err != nil {
+		t.Fatalf("RegisterDevice failed: %v", err)
+	}
+
 	if _, err := server.SendQueryUsersCommand("TEST001"); err != nil {
 		t.Fatalf("SendQueryUsersCommand failed: %v", err)
 	}
@@ -872,6 +920,10 @@ func TestSendQueryUsersCommand(t *testing.T) {
 func TestSendLogCommand(t *testing.T) {
 	server := NewADMSServer()
 	defer server.Close()
+
+	if err := server.RegisterDevice("TEST001"); err != nil {
+		t.Fatalf("RegisterDevice failed: %v", err)
+	}
 
 	if _, err := server.SendLogCommand("TEST001"); err != nil {
 		t.Fatalf("SendLogCommand failed: %v", err)
@@ -962,9 +1014,14 @@ func TestConcurrentAccess(t *testing.T) {
 	defer server.Close()
 	serialNumber := "TEST001"
 
+	// Register device first so QueueCommand calls succeed.
+	if err := server.RegisterDevice(serialNumber); err != nil {
+		t.Fatalf("RegisterDevice failed: %v", err)
+	}
+
 	var wg sync.WaitGroup
 
-	// Concurrent device registration
+	// Concurrent device registration (idempotent)
 	for range 10 {
 		wg.Go(func() {
 			_ = server.RegisterDevice(serialNumber)
@@ -1675,6 +1732,10 @@ func TestDrainCommands(t *testing.T) {
 	server := NewADMSServer()
 	defer server.Close()
 
+	if err := server.RegisterDevice("DRAIN001"); err != nil {
+		t.Fatalf("RegisterDevice failed: %v", err)
+	}
+
 	if _, err := server.QueueCommand("DRAIN001", "CMD1"); err != nil {
 		t.Fatalf("QueueCommand failed: %v", err)
 	}
@@ -1701,6 +1762,10 @@ func TestDrainCommands_DeletesKey(t *testing.T) {
 	server := NewADMSServer()
 	defer server.Close()
 
+	if err := server.RegisterDevice("DRAIN_DEL"); err != nil {
+		t.Fatalf("RegisterDevice failed: %v", err)
+	}
+
 	if _, err := server.QueueCommand("DRAIN_DEL", "INFO"); err != nil {
 		t.Fatalf("QueueCommand failed: %v", err)
 	}
@@ -1722,6 +1787,10 @@ func TestPendingCommandsCount(t *testing.T) {
 	// Zero for unknown device.
 	if n := server.PendingCommandsCount("NODEV"); n != 0 {
 		t.Errorf("expected 0 pending commands for unknown device, got %d", n)
+	}
+
+	if err := server.RegisterDevice("COUNT001"); err != nil {
+		t.Fatalf("RegisterDevice failed: %v", err)
 	}
 
 	// Queue a few commands and verify count without draining.
@@ -1908,22 +1977,40 @@ func TestWithMaxCommandsPerDevice(t *testing.T) {
 	defer server.Close()
 
 	sn := "CMD001"
-	for i := range 3 {
-		if _, err := server.QueueCommand(sn, "CMD"+string(rune('1'+i))); err != nil {
-			t.Fatalf("QueueCommand %d failed: %v", i+1, err)
-		}
+	if err := server.RegisterDevice(sn); err != nil {
+		t.Fatalf("RegisterDevice failed: %v", err)
 	}
 
-	// Fourth should fail.
+	ids := make([]int64, 3)
+	for i := range 3 {
+		id, err := server.QueueCommand(sn, "CMD"+string(rune('1'+i)))
+		if err != nil {
+			t.Fatalf("QueueCommand %d failed: %v", i+1, err)
+		}
+		ids[i] = id
+	}
+
+	// Fourth should fail — 3 queued + 0 pending = 3, which equals the limit.
 	_, err := server.QueueCommand(sn, "CMD4")
 	if !errors.Is(err, ErrCommandQueueFull) {
 		t.Errorf("expected ErrCommandQueueFull, got %v", err)
 	}
 
-	// Draining should free up space.
+	// Draining moves commands out of the queue, but they remain in
+	// pendingCommands until the device confirms execution. Simulate
+	// device confirmation via HandleDeviceCmd to free the slots.
 	_ = server.DrainCommands(sn)
+	for _, id := range ids {
+		body := fmt.Sprintf("ID=%d&Return=0&CMD=DATA", id)
+		req := httptest.NewRequest(http.MethodPost,
+			"/iclock/devicecmd?SN="+sn, strings.NewReader(body))
+		w := httptest.NewRecorder()
+		server.HandleDeviceCmd(w, req)
+	}
+
+	// Now all 3 pending entries are confirmed and removed; queueing should succeed.
 	if _, err := server.QueueCommand(sn, "CMD5"); err != nil {
-		t.Errorf("after drain, QueueCommand should succeed: %v", err)
+		t.Errorf("after drain+confirm, QueueCommand should succeed: %v", err)
 	}
 }
 
@@ -1931,8 +2018,12 @@ func TestWithMaxCommandsPerDevice_ZeroMeansUnlimited(t *testing.T) {
 	server := NewADMSServer(WithMaxCommandsPerDevice(0))
 	defer server.Close()
 
+	if err := server.RegisterDevice("DEV1"); err != nil {
+		t.Fatalf("RegisterDevice failed: %v", err)
+	}
+
 	for i := range 100 {
-		if _, err := server.QueueCommand("DEV1", "CMD"+string(rune(i))); err != nil {
+		if _, err := server.QueueCommand("DEV1", fmt.Sprintf("CMD_%d", i)); err != nil {
 			t.Fatalf("QueueCommand %d failed: %v", i, err)
 		}
 	}
@@ -2076,6 +2167,10 @@ func TestSendUserAddCommand_ReturnsError(t *testing.T) {
 	defer server.Close()
 	sn := "TEST001"
 
+	if err := server.RegisterDevice(sn); err != nil {
+		t.Fatalf("RegisterDevice failed: %v", err)
+	}
+
 	// First command should succeed.
 	if _, err := server.SendUserAddCommand(sn, "1001", "John", 0, ""); err != nil {
 		t.Fatalf("SendUserAddCommand failed: %v", err)
@@ -2092,6 +2187,10 @@ func TestSendUserDeleteCommand_ReturnsError(t *testing.T) {
 	server := NewADMSServer(WithMaxCommandsPerDevice(1))
 	defer server.Close()
 	sn := "TEST001"
+
+	if err := server.RegisterDevice(sn); err != nil {
+		t.Fatalf("RegisterDevice failed: %v", err)
+	}
 
 	// First command should succeed.
 	if _, err := server.SendUserDeleteCommand(sn, "1001"); err != nil {
@@ -2110,6 +2209,10 @@ func TestSendInfoCommand_ReturnsError(t *testing.T) {
 	defer server.Close()
 	sn := "TEST001"
 
+	if err := server.RegisterDevice(sn); err != nil {
+		t.Fatalf("RegisterDevice failed: %v", err)
+	}
+
 	// First command should succeed.
 	if _, err := server.SendInfoCommand(sn); err != nil {
 		t.Fatalf("SendInfoCommand failed: %v", err)
@@ -2127,6 +2230,10 @@ func TestSendCheckCommand_ReturnsError(t *testing.T) {
 	defer server.Close()
 	sn := "TEST001"
 
+	if err := server.RegisterDevice(sn); err != nil {
+		t.Fatalf("RegisterDevice failed: %v", err)
+	}
+
 	if _, err := server.SendCheckCommand(sn); err != nil {
 		t.Fatalf("SendCheckCommand failed: %v", err)
 	}
@@ -2141,6 +2248,10 @@ func TestSendGetOptionCommand_ReturnsError(t *testing.T) {
 	server := NewADMSServer(WithMaxCommandsPerDevice(1))
 	defer server.Close()
 	sn := "TEST001"
+
+	if err := server.RegisterDevice(sn); err != nil {
+		t.Fatalf("RegisterDevice failed: %v", err)
+	}
 
 	if _, err := server.SendGetOptionCommand(sn, "DeviceName"); err != nil {
 		t.Fatalf("SendGetOptionCommand failed: %v", err)
@@ -2157,6 +2268,10 @@ func TestSendShellCommand_ReturnsError(t *testing.T) {
 	defer server.Close()
 	sn := "TEST001"
 
+	if err := server.RegisterDevice(sn); err != nil {
+		t.Fatalf("RegisterDevice failed: %v", err)
+	}
+
 	if _, err := server.SendShellCommand(sn, "date"); err != nil {
 		t.Fatalf("SendShellCommand failed: %v", err)
 	}
@@ -2172,6 +2287,10 @@ func TestSendQueryUsersCommand_ReturnsError(t *testing.T) {
 	defer server.Close()
 	sn := "TEST001"
 
+	if err := server.RegisterDevice(sn); err != nil {
+		t.Fatalf("RegisterDevice failed: %v", err)
+	}
+
 	if _, err := server.SendQueryUsersCommand(sn); err != nil {
 		t.Fatalf("SendQueryUsersCommand failed: %v", err)
 	}
@@ -2186,6 +2305,10 @@ func TestSendLogCommand_ReturnsError(t *testing.T) {
 	server := NewADMSServer(WithMaxCommandsPerDevice(1))
 	defer server.Close()
 	sn := "TEST001"
+
+	if err := server.RegisterDevice(sn); err != nil {
+		t.Fatalf("RegisterDevice failed: %v", err)
+	}
 
 	if _, err := server.SendLogCommand(sn); err != nil {
 		t.Fatalf("SendLogCommand failed: %v", err)
@@ -2559,6 +2682,9 @@ func TestCommandIDIncrement(t *testing.T) {
 	server := NewADMSServer()
 	defer server.Close()
 	serialNumber := "IDTEST001"
+	if err := server.RegisterDevice(serialNumber); err != nil {
+		t.Fatalf("RegisterDevice failed: %v", err)
+	}
 
 	// Queue 3 commands.
 	for _, cmd := range []string{"INFO", "REBOOT", "CHECK"} {
@@ -2598,6 +2724,10 @@ func TestCommandIDIncrement_AcrossRequests(t *testing.T) {
 	server := NewADMSServer()
 	defer server.Close()
 
+	if err := server.RegisterDevice("DEV1"); err != nil {
+		t.Fatalf("RegisterDevice failed: %v", err)
+	}
+
 	// First request: 1 command → ID=1
 	if _, err := server.QueueCommand("DEV1", "INFO"); err != nil {
 		t.Fatal(err)
@@ -2626,6 +2756,12 @@ func TestCommandIDIncrement_AcrossRequests(t *testing.T) {
 func TestCommandIDIncrement_AcrossDevices(t *testing.T) {
 	server := NewADMSServer()
 	defer server.Close()
+
+	for _, sn := range []string{"DEVA", "DEVB"} {
+		if err := server.RegisterDevice(sn); err != nil {
+			t.Fatalf("RegisterDevice(%s) failed: %v", sn, err)
+		}
+	}
 
 	// Commands for different devices share the same ID counter.
 	if _, err := server.QueueCommand("DEVA", "INFO"); err != nil {
@@ -3123,15 +3259,15 @@ func TestHandleCData_DefaultTable_DeviceInfoQueueFull(t *testing.T) {
 	w2 := httptest.NewRecorder()
 	server.HandleCData(w2, req2)
 
-	// This dispatch should fail (queue full), but HandleCData still returns OK
-	// because device info dispatch failure is non-fatal (just logged as a warning).
+	// This dispatch should fail (queue full) and HandleCData returns 503
+	// to signal backpressure to the device.
 	req3 := httptest.NewRequest(http.MethodPost,
 		"/iclock/cdata?SN=DEV001", strings.NewReader(infoBody))
 	w3 := httptest.NewRecorder()
 	server.HandleCData(w3, req3)
 
-	if w3.Code != http.StatusOK {
-		t.Errorf("expected 200 (device info queue-full is non-fatal), got %d", w3.Code)
+	if w3.Code != http.StatusServiceUnavailable {
+		t.Errorf("expected 503 (device info queue-full), got %d", w3.Code)
 	}
 }
 
@@ -3212,15 +3348,15 @@ func TestHandleDeviceCmd_CallbackQueueFull(t *testing.T) {
 	w2 := httptest.NewRecorder()
 	server.HandleDeviceCmd(w2, req2)
 
-	// Next dispatch should fail (queue full) — but handler still returns OK.
+	// Next dispatch should fail (queue full) — handler returns 503.
 	req3 := httptest.NewRequest(http.MethodPost,
 		"/iclock/devicecmd?SN=DEV001", strings.NewReader(body))
 	w3 := httptest.NewRecorder()
 	server.HandleDeviceCmd(w3, req3)
 
-	// HandleDeviceCmd always responds OK regardless of queue status.
-	if w3.Code != http.StatusOK {
-		t.Errorf("expected 200, got %d", w3.Code)
+	// HandleDeviceCmd returns 503 when the callback queue is full.
+	if w3.Code != http.StatusServiceUnavailable {
+		t.Errorf("expected 503, got %d", w3.Code)
 	}
 }
 
@@ -3360,14 +3496,14 @@ func TestHandleRegistry_CallbackQueueFull(t *testing.T) {
 	w2 := httptest.NewRecorder()
 	server.HandleRegistry(w2, req2)
 
-	// Should still return OK (registry queue-full is non-fatal).
+	// Should return 503 (registry queue-full signals backpressure).
 	req3 := httptest.NewRequest(http.MethodPost,
 		"/iclock/registry?SN=DEV001", strings.NewReader(regBody))
 	w3 := httptest.NewRecorder()
 	server.HandleRegistry(w3, req3)
 
-	if w3.Code != http.StatusOK {
-		t.Errorf("expected 200, got %d", w3.Code)
+	if w3.Code != http.StatusServiceUnavailable {
+		t.Errorf("expected 503, got %d", w3.Code)
 	}
 }
 
@@ -3970,6 +4106,10 @@ func TestQueueCommand_ReturnsIncrementingIDs(t *testing.T) {
 	server := NewADMSServer()
 	defer server.Close()
 
+	if err := server.RegisterDevice("DEV001"); err != nil {
+		t.Fatalf("RegisterDevice failed: %v", err)
+	}
+
 	ids := make(map[int64]bool)
 	var prev int64
 	for i := range 10 {
@@ -4000,11 +4140,16 @@ func TestCommandResult_QueuedCommandPopulated(t *testing.T) {
 	)
 	defer server.Close()
 
-	// Queue a command so pendingCommands has the mapping.
+	if err := server.RegisterDevice("CORR001"); err != nil {
+		t.Fatalf("RegisterDevice failed: %v", err)
+	}
+
+	// Queue a command and drain it so pendingCommands has the mapping.
 	id, err := server.QueueCommand("CORR001", "DATA UPDATE USERINFO PIN=1\tName=Alice")
 	if err != nil {
 		t.Fatalf("QueueCommand failed: %v", err)
 	}
+	_ = server.DrainCommands("CORR001")
 
 	// Simulate the device confirming execution via POST /iclock/devicecmd.
 	body := fmt.Sprintf("ID=%d&Return=0&CMD=DATA", id)
@@ -4080,7 +4225,7 @@ func TestPendingCommands_CleanupOnEviction(t *testing.T) {
 		t.Fatalf("RegisterDevice failed: %v", err)
 	}
 
-	// Queue commands to populate pendingCommands.
+	// Queue commands, then drain to populate pendingCommands.
 	id1, err := server.QueueCommand("EVICT01", "CMD_A")
 	if err != nil {
 		t.Fatalf("QueueCommand A failed: %v", err)
@@ -4089,8 +4234,9 @@ func TestPendingCommands_CleanupOnEviction(t *testing.T) {
 	if err != nil {
 		t.Fatalf("QueueCommand B failed: %v", err)
 	}
+	_ = server.DrainCommands("EVICT01")
 
-	// Verify entries exist before eviction.
+	// Verify entries exist in pendingCommands before eviction.
 	server.queueMutex.Lock()
 	_, ok1 := server.pendingCommands[id1]
 	_, ok2 := server.pendingCommands[id2]
@@ -4342,6 +4488,10 @@ func TestSendQueryUsersCommand_ReturnsID(t *testing.T) {
 	server := NewADMSServer()
 	defer server.Close()
 
+	if err := server.RegisterDevice("QUSER001"); err != nil {
+		t.Fatalf("RegisterDevice failed: %v", err)
+	}
+
 	id, err := server.SendQueryUsersCommand("QUSER001")
 	if err != nil {
 		t.Fatalf("SendQueryUsersCommand failed: %v", err)
@@ -4433,16 +4583,15 @@ func TestHandleCData_USERINFO_CallbackQueueFull(t *testing.T) {
 	w2 := httptest.NewRecorder()
 	server.HandleCData(w2, req2)
 
-	// Now queue should be full — dispatch will fail but handler still returns 200.
+	// Now queue should be full — dispatch will fail and handler returns 503.
 	req3 := httptest.NewRequest(http.MethodPost,
 		"/iclock/cdata?SN=DEV001&table=USERINFO", strings.NewReader(userData))
 	w3 := httptest.NewRecorder()
 	server.HandleCData(w3, req3)
 
-	// USERINFO handler always returns 200 OK even when callback queue is full
-	// (it logs a warning instead of returning 503).
-	if w3.Code != http.StatusOK {
-		t.Errorf("expected 200, got %d", w3.Code)
+	// USERINFO handler returns 503 when callback queue is full.
+	if w3.Code != http.StatusServiceUnavailable {
+		t.Errorf("expected 503, got %d", w3.Code)
 	}
 }
 
@@ -5071,5 +5220,172 @@ func TestParseAttendance_WinterSummerTime(t *testing.T) {
 	summerExpected := time.Date(2024, 7, 15, 7, 0, 0, 0, time.UTC)
 	if !summerRecords[0].Timestamp.Equal(summerExpected) {
 		t.Errorf("summer: expected %v, got %v", summerExpected, summerRecords[0].Timestamp.UTC())
+	}
+}
+
+// ---------------------------------------------------------------------------
+// New tests for Items 1, 3, 4, 5 improvements
+// ---------------------------------------------------------------------------
+
+func TestQueueCommand_ReturnsErrDeviceNotFound(t *testing.T) {
+	server := NewADMSServer()
+	defer server.Close()
+
+	_, err := server.QueueCommand("NONEXISTENT", "INFO")
+	if !errors.Is(err, ErrDeviceNotFound) {
+		t.Errorf("expected ErrDeviceNotFound, got %v", err)
+	}
+}
+
+func TestSendInfoCommand_ReturnsErrDeviceNotFound(t *testing.T) {
+	server := NewADMSServer()
+	defer server.Close()
+
+	_, err := server.SendInfoCommand("NONEXISTENT")
+	if !errors.Is(err, ErrDeviceNotFound) {
+		t.Errorf("expected ErrDeviceNotFound, got %v", err)
+	}
+}
+
+func TestValidateCommandField_RejectsCRLF(t *testing.T) {
+	tests := []struct {
+		name  string
+		value string
+	}{
+		{"newline", "CMD\nINJECTED"},
+		{"carriage return", "CMD\rINJECTED"},
+		{"crlf", "CMD\r\nINJECTED"},
+		{"trailing newline", "CMD\n"},
+		{"leading newline", "\nCMD"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := validateCommandField("command", tc.value)
+			if !errors.Is(err, ErrInvalidCommandField) {
+				t.Errorf("expected ErrInvalidCommandField for %q, got %v", tc.value, err)
+			}
+		})
+	}
+}
+
+func TestValidateCommandField_AcceptsValid(t *testing.T) {
+	valid := []string{
+		"INFO",
+		"DATA UPDATE USERINFO PIN=1\tName=Alice",
+		"CHECK",
+		"SHELL echo hello",
+		"DATA QUERY USERINFO",
+	}
+
+	for _, v := range valid {
+		if err := validateCommandField("command", v); err != nil {
+			t.Errorf("expected nil for %q, got %v", v, err)
+		}
+	}
+}
+
+func TestQueueCommand_RejectsNewlineInCommand(t *testing.T) {
+	server := NewADMSServer()
+	defer server.Close()
+
+	if err := server.RegisterDevice("DEV001"); err != nil {
+		t.Fatalf("RegisterDevice failed: %v", err)
+	}
+
+	_, err := server.QueueCommand("DEV001", "INFO\nINJECTED")
+	if !errors.Is(err, ErrInvalidCommandField) {
+		t.Errorf("expected ErrInvalidCommandField, got %v", err)
+	}
+}
+
+func TestSendUserAddCommand_RejectsNewlineInFields(t *testing.T) {
+	server := NewADMSServer()
+	defer server.Close()
+
+	if err := server.RegisterDevice("DEV001"); err != nil {
+		t.Fatalf("RegisterDevice failed: %v", err)
+	}
+
+	_, err := server.SendUserAddCommand("DEV001", "1", "Alice\nINJECTED", 0, "")
+	if !errors.Is(err, ErrInvalidCommandField) {
+		t.Errorf("expected ErrInvalidCommandField for name with newline, got %v", err)
+	}
+
+	_, err = server.SendUserAddCommand("DEV001", "1\n2", "Alice", 0, "")
+	if !errors.Is(err, ErrInvalidCommandField) {
+		t.Errorf("expected ErrInvalidCommandField for pin with newline, got %v", err)
+	}
+}
+
+func TestSendShellCommand_RejectsNewline(t *testing.T) {
+	server := NewADMSServer()
+	defer server.Close()
+
+	if err := server.RegisterDevice("DEV001"); err != nil {
+		t.Fatalf("RegisterDevice failed: %v", err)
+	}
+
+	_, err := server.SendShellCommand("DEV001", "reboot\nrm -rf /")
+	if !errors.Is(err, ErrInvalidCommandField) {
+		t.Errorf("expected ErrInvalidCommandField, got %v", err)
+	}
+}
+
+func TestPendingCommands_CountedTowardLimit(t *testing.T) {
+	server := NewADMSServer(WithMaxCommandsPerDevice(2))
+	defer server.Close()
+
+	sn := "PENDING01"
+	if err := server.RegisterDevice(sn); err != nil {
+		t.Fatalf("RegisterDevice failed: %v", err)
+	}
+
+	// Queue 2 commands (hits the limit).
+	for i := range 2 {
+		if _, err := server.QueueCommand(sn, fmt.Sprintf("CMD_%d", i)); err != nil {
+			t.Fatalf("QueueCommand %d failed: %v", i, err)
+		}
+	}
+
+	// Drain moves them to pendingCommands.
+	_ = server.DrainCommands(sn)
+
+	// Queue is empty, but 2 pending commands exist — still at the limit.
+	_, err := server.QueueCommand(sn, "CMD_NEW")
+	if !errors.Is(err, ErrCommandQueueFull) {
+		t.Errorf("expected ErrCommandQueueFull (pending counted toward limit), got %v", err)
+	}
+}
+
+func TestClose_DeliversLiveContextToCallbacks(t *testing.T) {
+	ctxErrs := make(chan error, 10)
+	server := NewADMSServer(
+		WithOnDeviceInfo(func(ctx context.Context, _ string, _ map[string]string) {
+			ctxErrs <- ctx.Err()
+		}),
+	)
+
+	if err := server.RegisterDevice("DEV001"); err != nil {
+		t.Fatalf("RegisterDevice failed: %v", err)
+	}
+
+	// Dispatch a callback.
+	infoBody := "~DeviceName=TestDev\nMAC=00:11:22:33:44:55"
+	req := httptest.NewRequest(http.MethodPost,
+		"/iclock/cdata?SN=DEV001", strings.NewReader(infoBody))
+	w := httptest.NewRecorder()
+	server.HandleCData(w, req)
+
+	// Close drains the callback queue; callbacks should receive a live context.
+	server.Close()
+
+	select {
+	case err := <-ctxErrs:
+		if err != nil {
+			t.Errorf("expected live context (nil Err) during callback drain, got %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for callback")
 	}
 }

--- a/examples/basic/main_test.go
+++ b/examples/basic/main_test.go
@@ -300,14 +300,14 @@ func TestCommandHandler_UnknownDevice(t *testing.T) {
 	server := newTestServer(t) // no devices registered
 	handler := commandHandler(server)
 
-	// QueueCommand succeeds even for unknown serials (it just queues
-	// the command for later pickup), so we expect 200.
+	// QueueCommand now rejects unknown devices with ErrDeviceNotFound,
+	// so the command handler returns 503.
 	req := httptest.NewRequest(http.MethodPost, "/command?sn=NOSUCH&cmd=REBOOT", nil)
 	w := httptest.NewRecorder()
 	handler.ServeHTTP(w, req)
 
-	if w.Code != http.StatusOK {
-		t.Errorf("expected 200 for unknown device (queue accepts it), got %d", w.Code)
+	if w.Code != http.StatusServiceUnavailable {
+		t.Errorf("expected 503 for unknown device, got %d", w.Code)
 	}
 }
 


### PR DESCRIPTION
…lidation, docs

- Item 1: Move baseCtxCancel() after callback drain so callbacks get a live context during Close() shutdown
- Item 2: Return HTTP 503 consistently when callback queue is full (USERINFO, device info, registry, command result handlers)
- Item 3: Reject QueueCommand for unregistered devices with ErrDeviceNotFound, closing the orphaned memory leak path
- Item 4: Count pending (drained but unconfirmed) commands toward the per-device limit; move pendingCommands insertion from QueueCommand to DrainCommands to avoid double-counting
- Item 5: Add validateCommandField rejecting CR/LF injection in QueueCommand, SendUserAddCommand, SendUserDeleteCommand, SendGetOptionCommand, and SendShellCommand
- Item 6: Fix README and GETTING_STARTED command signatures, API table, and stale DATA QUERY note

Adds 10 new tests covering ErrDeviceNotFound, CRLF validation, pending-commands cap, and live-context-during-drain. 