### PR TITLE
Extend golangci-lint

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,100 @@
+name: Lint
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  golangci:
+    name: golangci-lint
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Set up Go
+        uses: actions/setup-go@v6
+        with:
+          go-version: '1.26.x'
+          check-latest: true
+          cache: true
+
+      # Build golangci-lint from source with the project's Go toolchain so it
+      # supports the Go language version declared in go.mod (which may be newer
+      # than the version bundled in published golangci-lint binaries).
+      - name: Install golangci-lint
+        run: go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@latest
+
+      - name: Run golangci-lint
+        run: golangci-lint run --timeout=5m ./...
+
+  gofumpt:
+    name: gofumpt formatting
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Set up Go
+        uses: actions/setup-go@v6
+        with:
+          go-version: '1.26.x'
+          check-latest: true
+          cache: true
+
+      - name: Install gofumpt
+        run: go install mvdan.cc/gofumpt@latest
+
+      - name: Run gofumpt
+        run: |
+          out="$(gofumpt -l .)"
+          if [ -n "$out" ]; then
+            echo "The following files are not gofumpt-formatted:"
+            echo "$out"
+            echo
+            echo "Diff:"
+            gofumpt -d .
+            exit 1
+          fi
+
+  govulncheck:
+    name: govulncheck
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Set up Go
+        uses: actions/setup-go@v6
+        with:
+          go-version: '1.26.x'
+          check-latest: true
+          cache: true
+
+      - name: Install govulncheck
+        run: go install golang.org/x/vuln/cmd/govulncheck@v1.3.0
+
+      - name: Run govulncheck
+        run: govulncheck ./...
+
+  modernize:
+    name: modernize analyzer
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Set up Go
+        uses: actions/setup-go@v6
+        with:
+          go-version: '1.26.x'
+          check-latest: true
+          cache: true
+
+      - name: Run modernize
+        run: go run golang.org/x/tools/gopls/internal/analysis/modernize/cmd/modernize@v0.21.1 ./...

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -2,7 +2,7 @@ name: Lint
 
 on:
   push:
-    branches: [main]
+    branches: [master]
   pull_request:
   workflow_dispatch:
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,20 +18,15 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version: "1.26.x"
 
       - name: Vet
         run: go vet ./...
-
-      - name: Lint
-        uses: golangci/golangci-lint-action@v7
-        with:
-          version: v2.11.3
 
       - name: Build
         run: go build ./...
@@ -45,7 +40,7 @@ jobs:
         run: go test -v -race -coverprofile=coverage.out ./...
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@v6
         with:
           files: coverage.out
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -2,23 +2,32 @@ version: "2"
 
 run:
   go: "1.26"
+  timeout: 5m
+  tests: true
 
 linters:
   default: standard
   enable:
+    # correctness / safety
     - copyloopvar
     - errname
     - gochecknoinits
+    - makezero
+    - nilerr
+    # idiomatic / modern
+    - intrange
+    - modernize
+    - usestdlibvars
+    # style / quality
     - gocritic
     - goprintffuncname
-    - makezero
     - misspell
-    - nilerr
     - prealloc
+    - revive
     - unconvert
     - unparam
-    - usestdlibvars
     - whitespace
+
   settings:
     errcheck:
       exclude-functions:
@@ -28,13 +37,46 @@ linters:
         - fmt.Fprintln
     gocritic:
       disabled-checks:
-        - commentFormatting # we have our own style
+        - commentFormatting   # we have our own style
+        - ifElseChain
+        - singleCaseSwitch
+      enabled-tags:
+        - diagnostic
+        - performance
+        - style
     misspell:
       locale: US
     prealloc:
       simple: true
       range-loops: true
       for-loops: false
+    revive:
+      severity: warning
+      rules:
+        - name: blank-imports
+        - name: context-as-argument
+        - name: context-keys-type
+        - name: dot-imports
+        - name: error-return
+        - name: error-strings
+        - name: error-naming
+        - name: increment-decrement
+        - name: range
+        - name: receiver-naming
+        - name: redefines-builtin-id
+        - name: superfluous-else
+        - name: time-naming
+        - name: unexported-return
+        - name: unreachable-code
+        - name: unused-parameter
+        - name: var-declaration
+        - name: var-naming
+    staticcheck:
+      # "all" enables ST/SA/QF/S checks; modernize-style suggestions ship via QF/S.
+      checks:
+        - all
+        - -ST1000   # missing package comment - too noisy
+
   exclusions:
     presets:
       - std-error-handling
@@ -48,8 +90,24 @@ linters:
         linters:
           - errcheck
           - gocritic
+      # Tests get more leeway.
+      - path: _test\.go
+        linters:
+          - errcheck
+          - unparam
+          - gocritic
+          - revive
+          - prealloc
 
 formatters:
   enable:
     - gofmt
     - goimports
+  settings:
+    goimports:
+      local-prefixes:
+        - github.com/s0x90/zkteco-adms
+
+issues:
+  max-issues-per-linter: 0
+  max-same-issues: 0

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -68,7 +68,6 @@ linters:
         - name: time-naming
         - name: unexported-return
         - name: unreachable-code
-        - name: unused-parameter
         - name: var-declaration
         - name: var-naming
     staticcheck:

--- a/cmd/probe/main_test.go
+++ b/cmd/probe/main_test.go
@@ -516,7 +516,7 @@ func TestPrintSummary_ConcurrentSafe(t *testing.T) {
 
 	var wg sync.WaitGroup
 	for range 5 {
-		wg.Go(func(){
+		wg.Go(func() {
 			printSummary(&mu, results, queued, 1)
 		})
 	}

--- a/cmd/probe/main_test.go
+++ b/cmd/probe/main_test.go
@@ -516,11 +516,9 @@ func TestPrintSummary_ConcurrentSafe(t *testing.T) {
 
 	var wg sync.WaitGroup
 	for range 5 {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
+		wg.Go(func(){
 			printSummary(&mu, results, queued, 1)
-		}()
+		})
 	}
 	wg.Wait()
 	t.Log("concurrent printSummary completed without panic or race")

--- a/parser.go
+++ b/parser.go
@@ -39,7 +39,7 @@ func validateSerialNumber(sn string) error {
 // The loc parameter specifies the timezone in which device-local timestamps
 // (the "2006-01-02 15:04:05" format) are interpreted. Unix epoch timestamps
 // are inherently UTC and are not affected by loc.
-func (s *ADMSServer) parseAttendanceRecords(data string, serialNumber string, loc *time.Location) []AttendanceRecord {
+func (s *ADMSServer) parseAttendanceRecords(data, serialNumber string, loc *time.Location) []AttendanceRecord {
 	var records []AttendanceRecord
 	var skipped int
 


### PR DESCRIPTION
Pull in revive (curated rule set), modernize, intrange, and staticcheck 'all -ST1000'

Move linting out of the test workflow into a dedicated lint.yml that runs golangci-lint, gofumpt, govulncheck, and the modernize analyzer, and bump checkout/setup-go/codecov action versions.